### PR TITLE
Improve small dataset training stability

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -28,7 +28,7 @@ model_params:
 
 optimizer_params:
   lr: 0.0005
-  pct_start: 0.0
+  pct_start: 0.1
 
 # this is a very basic early stopping based off learning rate - when it falls to 0 and remains there for 3 epochs, the training stops
 enable_early_stopping: True
@@ -45,3 +45,20 @@ diagonal_attention_prior_weight: 0.1
 # stabilizes ASR training for smaller datasets
 entropy_params:
   label_smoothing: 0.1
+
+dataset_params:
+  # SpecAugment parameters applied only on the training split.
+  spec_augment:
+    apply_prob: 0.5
+    freq_mask_param: 13
+    time_mask_param: 50
+    num_freq_masks: 2
+    num_time_masks: 2
+
+dataloader_params:
+  train_num_workers: 8
+  val_num_workers: 2
+
+loss_weights:
+  ctc: 0.8
+  s2s: 1.0

--- a/README.md
+++ b/README.md
@@ -20,7 +20,27 @@ python train.py --config_path ./Configs/config.yml
 ```
 Please specify the training and validation data in `config.yml` file. The data list format needs to be `filename.wav|label-in-espeak-phonemes|speaker_number`, see [train_list.txt](https://github.com/martinambrus/AuxiliaryASR/blob/main/Data/train_list.txt) as an example (a custom sample of phonemized WAV files used for English training). Note that `speaker_number` can just be `0` for ASR, but it is useful to set a meaningful number for TTS training in StyleTTS2. 
 
-Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take - but not beyond 64, as anything beyond this value did not yield desired results in my testing. Please note that `batch_size = 64` will take around 10G GPU RAM. 
+Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take - but not beyond 64, as anything beyond this value did not yield desired results in my testing. Please note that `batch_size = 64` will take around 10G GPU RAM.
+
+### Training on smaller datasets
+
+Fine-tuning on very small corpora (a few hours of speech or less) tends to overfit quickly. The default `config.yml` now enables a light SpecAugment policy and a slightly smaller weight for the CTC branch (`loss_weights.ctc`). You can tweak those options to better fit your use case:
+
+```yaml
+dataset_params:
+  spec_augment:
+    apply_prob: 0.5    # probability of applying SpecAugment on a batch
+    freq_mask_param: 13
+    time_mask_param: 50
+    num_freq_masks: 2
+    num_time_masks: 2
+
+loss_weights:
+  ctc: 0.8             # reduce to 0.5-0.7 for extremely small datasets
+  s2s: 1.0
+```
+
+Increasing the warm-up ratio (`optimizer_params.pct_start`) or reducing the batch size can also help when the number of training utterances is limited.
 
 ### Languages
 This repo is set up for English with the [phonemizer](https://github.com/bootphon/phonemizer) package and espeak-ng backend. You can train it with other languages. If you would like to train for datasets in different languages, you will need to change the vocabulary file ([word_index_dict.txt](https://github.com/martinambrus/AuxiliaryASR/blob/main/word_index_dict.txt)) to contain the phonemes in your dataset. There is a utility script ([words_index_extractor.py](https://github.com/martinambrus/AuxiliaryASR/blob/main/words_index_extractor.py)) which will generate (and **_rewrite_**!) the file words_index_dict.txt when ran. Here's the syntax to use to generate this file:

--- a/meldataset.py
+++ b/meldataset.py
@@ -12,6 +12,7 @@ from torch import nn
 import torch.nn.functional as F
 import torchaudio
 from torch.utils.data import DataLoader
+from torchaudio import transforms as T
 
 from nltk.tokenize import word_tokenize
 #import phonemizer
@@ -36,6 +37,49 @@ DEFAULT_DICT_PATH = osp.join(osp.dirname(__file__), 'word_index_dict.txt')
 # }
 
 #global_phonemizer = phonemizer.backend.EspeakBackend(language='en-us', preserve_punctuation=True,  with_stress=True)
+
+
+class SpecAugment:
+    """Simple SpecAugment implementation for log-mel spectrograms."""
+
+    def __init__(self,
+                 freq_mask_param=27,
+                 time_mask_param=40,
+                 num_freq_masks=2,
+                 num_time_masks=2,
+                 apply_prob=1.0):
+        self.freq_mask_param = int(freq_mask_param)
+        self.time_mask_param = int(time_mask_param)
+        self.num_freq_masks = int(num_freq_masks)
+        self.num_time_masks = int(num_time_masks)
+        self.apply_prob = float(apply_prob)
+
+        self._freq_mask = T.FrequencyMasking(freq_mask_param=self.freq_mask_param)
+        self._time_mask = T.TimeMasking(time_mask_param=self.time_mask_param)
+
+    def __call__(self, mel_tensor: torch.Tensor) -> torch.Tensor:
+        if self.apply_prob < 1.0 and random.random() > self.apply_prob:
+            return mel_tensor
+
+        squeeze = False
+        if mel_tensor.dim() == 2:
+            mel_tensor = mel_tensor.unsqueeze(0)
+            squeeze = True
+
+        augmented = mel_tensor.clone()
+
+        for _ in range(max(0, self.num_freq_masks)):
+            augmented = self._freq_mask(augmented)
+
+        for _ in range(max(0, self.num_time_masks)):
+            augmented = self._time_mask(augmented)
+
+        if squeeze:
+            augmented = augmented.squeeze(0)
+
+        return augmented
+
+
 class MelDataset(torch.utils.data.Dataset):
     def __init__(self,
                  data_list,
@@ -48,7 +92,9 @@ class MelDataset(torch.utils.data.Dataset):
                  },
                  mel_params={
                      "n_mels": 80
-                 }
+                 },
+                 spec_augment_params=None,
+                 validation=False
                 ):
 
         self.data_list = data_list
@@ -56,6 +102,14 @@ class MelDataset(torch.utils.data.Dataset):
         self.sr = sr
 
         self.to_melspec = torchaudio.transforms.MelSpectrogram(**mel_params)
+
+        self.spec_augment = None
+        if spec_augment_params and not validation:
+            try:
+                self.spec_augment = SpecAugment(**spec_augment_params)
+            except TypeError:
+                logger.warning(f"Invalid SpecAugment configuration: {spec_augment_params}. Skipping augmentation.")
+                self.spec_augment = None
 
         # https://github.com/yl4579/StyleTTS/issues/57
         self.mean, self.std = -4, 4
@@ -75,7 +129,12 @@ class MelDataset(torch.utils.data.Dataset):
                     mel_tensor.unsqueeze(0), size=(text_tensor.size(0)+1)*3, align_corners=False,
                     mode='linear').squeeze(0)
 
-            acoustic_feature = (torch.log(1e-5 + mel_tensor) - self.mean)/self.std
+            log_mel_tensor = torch.log(1e-5 + mel_tensor)
+
+            if self.spec_augment is not None:
+                log_mel_tensor = self.spec_augment(log_mel_tensor)
+
+            acoustic_feature = (log_mel_tensor - self.mean)/self.std
 
             length_feature = acoustic_feature.size(1)
             acoustic_feature = acoustic_feature[:, :(length_feature - length_feature % 2)]
@@ -203,7 +262,7 @@ def build_dataloader(path_list,
                      collate_config={},
                      dataset_config={}):
 
-    dataset = MelDataset(path_list, **dataset_config)
+    dataset = MelDataset(path_list, validation=validation, **dataset_config)
     collate_fn = Collater(**collate_config)
     data_loader = DataLoader(dataset,
                              batch_size=batch_size,

--- a/models.py
+++ b/models.py
@@ -136,9 +136,12 @@ class ASRS2S(nn.Module):
         """
         self.initialize_decoder_states(memory, memory_mask)
         # text random mask
-        random_mask = (torch.rand(text_input.shape) < self.random_mask).to(text_input.device)
-        _text_input = text_input.clone()
-        _text_input.masked_fill_(random_mask, self.unk_index)
+        if self.training and self.random_mask > 0:
+            random_mask = (torch.rand(text_input.shape, device=text_input.device) < self.random_mask)
+            _text_input = text_input.clone()
+            _text_input.masked_fill_(random_mask, self.unk_index)
+        else:
+            _text_input = text_input
         decoder_inputs = self.embedding(_text_input).transpose(0, 1) # -> [T, B, channel]
         start_embedding = self.embedding(
             torch.LongTensor([self.sos]*decoder_inputs.size(1)).to(decoder_inputs.device))

--- a/train.py
+++ b/train.py
@@ -141,6 +141,16 @@ def main(config_path):
         'mel_params': cfg_get_nested( config, 'preprocess_params.mel_params', { 'n_mels': 80 })
     }
 
+    dataset_additional_params = cfg_get_nested(config, 'dataset_params', {})
+    if isinstance(dataset_additional_params, dict):
+        for override_key in ('dict_path', 'sr', 'spect_params', 'mel_params'):
+            if override_key in dataset_additional_params:
+                dataset_params[override_key] = dataset_additional_params[override_key]
+
+        spec_augment_config = dataset_additional_params.get('spec_augment')
+        if spec_augment_config:
+            dataset_params['spec_augment_params'] = spec_augment_config
+
     train_list, val_list = get_data_path_list(train_path, val_path)
 
     # sort data list by duration for consistent bucketing and batching
@@ -152,27 +162,31 @@ def main(config_path):
     train_list = [l[:-1].split('|') for l in train_list]
     val_list = [l[:-1].split('|') for l in val_list]
 
+    dataloader_params = cfg_get_nested(config, 'dataloader_params', {})
+    train_num_workers = int(dataloader_params.get('train_num_workers', 8))
+    val_num_workers = int(dataloader_params.get('val_num_workers', 2))
+
     sorted_train_dataloader = build_dataloader(train_list_sorted,
                                         batch_size=batch_size,
-                                        num_workers=8,
+                                        num_workers=train_num_workers,
                                         dataset_config=dataset_params,
                                         device=device)
     shuffled_train_dataloader = build_dataloader(train_list,
                                             batch_size=batch_size,
-                                            num_workers=8,
+                                            num_workers=train_num_workers,
                                             dataset_config=dataset_params,
                                             device=device)
 
     sorted_val_dataloader = build_dataloader(val_list_sorted,
                                       batch_size=batch_size,
                                       validation=True,
-                                      num_workers=2,
+                                      num_workers=val_num_workers,
                                       device=device,
                                       dataset_config=dataset_params)
     shuffled_val_dataloader = build_dataloader(val_list,
                                           batch_size=batch_size,
                                           validation=True,
-                                          num_workers=2,
+                                          num_workers=val_num_workers,
                                           device=device,
                                           dataset_config=dataset_params)
 
@@ -199,7 +213,7 @@ def main(config_path):
 
     scheduler_params = {
             'max_lr': float(cfg_get_nested( config, 'optimizer_params.lr', 5e-4)),
-            'pct_start': float(cfg_get_nested( config, 'optimizer_params.pct_start', 0.0)),
+            'pct_start': float(cfg_get_nested( config, 'optimizer_params.pct_start', 0.1)),
             'epochs': epochs,
             'steps_per_epoch': len(sorted_train_dataloader),
         }
@@ -220,6 +234,10 @@ def main(config_path):
     else:
         early_stopping = None
 
+    loss_weight_config = cfg_get_nested(config, 'loss_weights', {}) or {}
+    ctc_weight = float(loss_weight_config.get('ctc', 1.0))
+    s2s_weight = float(loss_weight_config.get('s2s', 1.0))
+
     trainer = Trainer(model=model,
                     criterion=criterion,
                     optimizer=optimizer,
@@ -233,6 +251,8 @@ def main(config_path):
                     switch_sortagrad_dataset_epoch=cfg_get_nested( config, 'sortagrad_switch_to_shuffled_dataset_epoch', 10),
                     use_diagonal_attention_prior=cfg_get_nested( config, 'use_diagonal_attention_prior', True),
                     diagonal_attention_prior_weight=cfg_get_nested( config, 'diagonal_attention_prior_weight', 0.1),
+                    ctc_weight=ctc_weight,
+                    s2s_weight=s2s_weight,
                     )
 
     pretrained_model = cfg_get_nested( config, 'pretrained_model', '' )

--- a/trainer.py
+++ b/trainer.py
@@ -37,7 +37,9 @@ class Trainer(object):
                  initial_epochs=0,
                  switch_sortagrad_dataset_epoch = 10,
                  use_diagonal_attention_prior = True,
-                 diagonal_attention_prior_weight = 0.1):
+                 diagonal_attention_prior_weight = 0.1,
+                 ctc_weight=1.0,
+                 s2s_weight=1.0):
 
         self.steps = initial_steps
         self.epochs = initial_epochs
@@ -60,6 +62,8 @@ class Trainer(object):
         self.use_diagonal_attention_prior = use_diagonal_attention_prior
         self.diagonal_attention_prior_weight = diagonal_attention_prior_weight
         self.maxm_mem_usage = 0
+        self.ctc_weight = ctc_weight
+        self.s2s_weight = s2s_weight
 
     def save_checkpoint(self, checkpoint_path):
         """Save checkpoint.
@@ -198,10 +202,10 @@ class Trainer(object):
             loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
         loss_s2s /= text_input.size(0)
 
+        total_loss = self.ctc_weight * loss_ctc + self.s2s_weight * loss_s2s
         if self.use_diagonal_attention_prior:
-            loss = loss_ctc + loss_s2s + self.diagonal_attention_prior_weight * loss_diagonal
-        else:
-            loss = loss_ctc + loss_s2s
+            total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
+        loss = total_loss
         loss.backward()
         torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
         self.optimizer.step()


### PR DESCRIPTION
## Summary
- add configurable SpecAugment for the training dataset and allow overriding dataloader settings
- expose per-branch loss weights and tighten the OneCycle warmup defaults for better small-corpus behavior
- document the new options in the README and surface recommended defaults in the config file

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2816afd4c83329edef09392f5df58