### PR TITLE
Add transformer-style encoder blocks

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -25,6 +25,35 @@ model_params:
    token_embedding_dim: 512
    n_layers: 5
    location_kernel_size: 31
+   encoder_type: "conformer"
+   encoder_heads: 4
+   encoder_dropout: 0.1
+   encoder_ffn_expansion: 4.0
+   encoder_conv_kernel_size: 31
+   encoder_block_sequence:
+     - type: "conformer"
+       enabled: true
+       layers: 5
+   encoder_block_config:
+     conformer:
+       use_macaron: true
+       use_conv_module: true
+     emformer:
+       use_conv_module: true
+       chunk_size: 64
+       left_context: 64
+       right_context: 16
+     branchformer:
+       enable_attn_branch: true
+       enable_conv_branch: true
+       enable_ffn_branch: true
+       branch_dropout: 0.1
+       post_ffn: true
+     zipformer:
+       use_attention: true
+       use_convolution: true
+       use_ffn_stream: true
+       post_ffn: true
 
 optimizer_params:
   lr: 0.0005

--- a/layers.py
+++ b/layers.py
@@ -1,7 +1,6 @@
-import math
 import torch
 from torch import nn
-from typing import Optional, Any
+from typing import Optional, Any, Dict, List
 from torch import Tensor
 import torch.nn.functional as F
 import torchaudio
@@ -129,6 +128,482 @@ class ConvBlock(nn.Module):
             nn.Dropout(p=dropout_p)
         ]
         return nn.Sequential(*layers)
+
+
+class FeedForwardModule(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 expansion_factor: float = 4.0,
+                 dropout: float = 0.1,
+                 activation: str = 'swish',
+                 use_layer_norm: bool = True):
+        super().__init__()
+        inner_dim = int(hidden_dim * expansion_factor)
+        self.layer_norm = nn.LayerNorm(hidden_dim) if use_layer_norm else None
+        self.linear1 = nn.Linear(hidden_dim, inner_dim)
+        self.activation = _get_activation_fn(activation)
+        self.dropout = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(inner_dim, hidden_dim)
+        self.dropout2 = nn.Dropout(dropout)
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self.layer_norm is not None:
+            x = self.layer_norm(x)
+        x = self.linear1(x)
+        x = self.activation(x)
+        x = self.dropout(x)
+        x = self.linear2(x)
+        x = self.dropout2(x)
+        return x
+
+
+class MultiHeadSelfAttentionModule(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 num_heads: int = 4,
+                 dropout: float = 0.1,
+                 use_layer_norm: bool = True):
+        super().__init__()
+        self.layer_norm = nn.LayerNorm(hidden_dim) if use_layer_norm else None
+        self.attention = nn.MultiheadAttention(
+            embed_dim=hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            batch_first=True,
+        )
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None,
+                attn_mask: Optional[Tensor] = None) -> Tensor:
+        attn_input = x
+        if self.layer_norm is not None:
+            attn_input = self.layer_norm(attn_input)
+        attn_output, _ = self.attention(
+            attn_input,
+            attn_input,
+            attn_input,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+            need_weights=False,
+        )
+        attn_output = self.dropout(attn_output)
+        return attn_output
+
+
+class ConformerConvolutionModule(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 kernel_size: int = 31,
+                 dropout: float = 0.1,
+                 activation: str = 'swish',
+                 use_layer_norm: bool = True):
+        super().__init__()
+        if kernel_size % 2 == 0:
+            raise ValueError("kernel_size must be odd for depthwise convolution")
+        self.layer_norm = nn.LayerNorm(hidden_dim) if use_layer_norm else None
+        self.pointwise_conv1 = nn.Conv1d(hidden_dim, 2 * hidden_dim, kernel_size=1)
+        self.glu = nn.GLU(dim=1)
+        self.depthwise_conv = nn.Conv1d(
+            hidden_dim,
+            hidden_dim,
+            kernel_size=kernel_size,
+            padding=kernel_size // 2,
+            groups=hidden_dim,
+        )
+        self.batch_norm = nn.BatchNorm1d(hidden_dim)
+        self.activation = _get_activation_fn(activation)
+        self.pointwise_conv2 = nn.Conv1d(hidden_dim, hidden_dim, kernel_size=1)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: Tensor) -> Tensor:
+        residual = x
+        if self.layer_norm is not None:
+            x = self.layer_norm(x)
+        x = x.transpose(1, 2)
+        x = self.pointwise_conv1(x)
+        x = self.glu(x)
+        x = self.depthwise_conv(x)
+        x = self.batch_norm(x)
+        x = self.activation(x)
+        x = self.pointwise_conv2(x)
+        x = x.transpose(1, 2)
+        x = self.dropout(x)
+        return x
+
+
+class ConformerBlock(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 num_heads: int = 4,
+                 expansion_factor: float = 4.0,
+                 dropout: float = 0.1,
+                 conv_kernel_size: int = 31,
+                 use_macaron: bool = True,
+                 use_conv_module: bool = True,
+                 activation: str = 'swish'):
+        super().__init__()
+        self.use_macaron = use_macaron
+        self.ff_scale = 0.5 if use_macaron else 1.0
+        self.feed_forward1 = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+        )
+        self.self_attn = MultiHeadSelfAttentionModule(
+            hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+        )
+        self.conv_module = ConformerConvolutionModule(
+            hidden_dim,
+            kernel_size=conv_kernel_size,
+            dropout=dropout,
+            activation=activation,
+        ) if use_conv_module else None
+        self.feed_forward2 = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+        )
+        self.final_layer_norm = nn.LayerNorm(hidden_dim)
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None) -> Tensor:
+        if self.use_macaron:
+            x = x + self.ff_scale * self.feed_forward1(x)
+        else:
+            x = x + self.feed_forward1(x)
+
+        attn_out = self.self_attn(x, key_padding_mask=key_padding_mask)
+        x = x + attn_out
+
+        if self.conv_module is not None:
+            conv_out = self.conv_module(x)
+            x = x + conv_out
+
+        x = x + self.ff_scale * self.feed_forward2(x)
+        x = self.final_layer_norm(x)
+        return x
+
+
+class EmformerBlock(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 num_heads: int = 4,
+                 expansion_factor: float = 4.0,
+                 dropout: float = 0.1,
+                 conv_kernel_size: int = 31,
+                 chunk_size: int = 64,
+                 left_context: int = 64,
+                 right_context: int = 16,
+                 activation: str = 'swish',
+                 use_conv_module: bool = True):
+        super().__init__()
+        self.feed_forward = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+        )
+        self.self_attn = MultiHeadSelfAttentionModule(
+            hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+        )
+        self.conv_module = ConformerConvolutionModule(
+            hidden_dim,
+            kernel_size=conv_kernel_size,
+            dropout=dropout,
+            activation=activation,
+        ) if use_conv_module else None
+        self.final_layer_norm = nn.LayerNorm(hidden_dim)
+        self.chunk_size = max(1, chunk_size)
+        self.left_context = max(0, left_context)
+        self.right_context = max(0, right_context)
+        self._cached_base_masks: Dict[int, Tensor] = {}
+
+    def _build_local_mask(self, seq_len: int, device: torch.device) -> Optional[Tensor]:
+        total_left = self.left_context + self.chunk_size - 1
+        total_right = self.right_context
+        window = total_left + total_right + 1
+        if window >= seq_len:
+            return None
+        if seq_len not in self._cached_base_masks:
+            base_mask = torch.full((seq_len, seq_len), float('-inf'))
+            for index in range(seq_len):
+                start = max(0, index - total_left)
+                end = min(seq_len, index + total_right + 1)
+                base_mask[index, start:end] = 0.0
+            self._cached_base_masks[seq_len] = base_mask
+        mask = self._cached_base_masks[seq_len]
+        if mask.device != device:
+            mask = mask.to(device)
+        return mask
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None) -> Tensor:
+        x = x + self.feed_forward(x)
+        attn_mask = self._build_local_mask(x.size(1), x.device)
+        attn_out = self.self_attn(
+            x,
+            key_padding_mask=key_padding_mask,
+            attn_mask=attn_mask,
+        )
+        x = x + attn_out
+
+        if self.conv_module is not None:
+            x = x + self.conv_module(x)
+
+        x = self.final_layer_norm(x)
+        return x
+
+
+class BranchformerBlock(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 num_heads: int = 4,
+                 expansion_factor: float = 4.0,
+                 dropout: float = 0.1,
+                 conv_kernel_size: int = 31,
+                 activation: str = 'swish',
+                 enable_attn_branch: bool = True,
+                 enable_conv_branch: bool = True,
+                 enable_ffn_branch: bool = True,
+                 branch_dropout: float = 0.1,
+                 post_ffn: bool = True):
+        super().__init__()
+        self.pre_norm = nn.LayerNorm(hidden_dim)
+        self.enable_attn_branch = enable_attn_branch
+        self.enable_conv_branch = enable_conv_branch
+        self.enable_ffn_branch = enable_ffn_branch
+        self.branch_dropout = nn.Dropout(branch_dropout)
+        self.attn_branch = MultiHeadSelfAttentionModule(
+            hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            use_layer_norm=False,
+        ) if enable_attn_branch else None
+        self.conv_branch = ConformerConvolutionModule(
+            hidden_dim,
+            kernel_size=conv_kernel_size,
+            dropout=dropout,
+            activation=activation,
+            use_layer_norm=False,
+        ) if enable_conv_branch else None
+        self.ffn_branch = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+            use_layer_norm=False,
+        ) if enable_ffn_branch else None
+        self.num_branches = sum([
+            1 if enable_attn_branch else 0,
+            1 if enable_conv_branch else 0,
+            1 if enable_ffn_branch else 0,
+        ])
+        self.branch_weights = nn.Parameter(torch.ones(self.num_branches)) if self.num_branches > 1 else None
+        self.post_ffn = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+        ) if post_ffn else None
+        self.final_layer_norm = nn.LayerNorm(hidden_dim)
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None) -> Tensor:
+        residual = x
+        x_norm = self.pre_norm(x)
+        branches: List[Tensor] = []
+        if self.attn_branch is not None:
+            attn_out = self.attn_branch(x_norm, key_padding_mask=key_padding_mask)
+            branches.append(attn_out)
+        if self.conv_branch is not None:
+            conv_out = self.conv_branch(x_norm)
+            branches.append(conv_out)
+        if self.ffn_branch is not None:
+            ffn_out = self.ffn_branch(x_norm)
+            branches.append(ffn_out)
+
+        if not branches:
+            mixed = torch.zeros_like(x)
+        elif len(branches) == 1:
+            mixed = branches[0]
+        else:
+            stacked = torch.stack(branches, dim=-1)  # (B, T, H, num_branches)
+            weights = torch.softmax(self.branch_weights, dim=0)
+            weights = weights.view(1, 1, 1, -1)
+            mixed = (stacked * weights).sum(dim=-1)
+
+        mixed = self.branch_dropout(mixed)
+        x = residual + mixed
+
+        if self.post_ffn is not None:
+            x = x + self.post_ffn(x)
+
+        x = self.final_layer_norm(x)
+        return x
+
+
+class ZipformerBlock(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 num_heads: int = 4,
+                 expansion_factor: float = 4.0,
+                 dropout: float = 0.1,
+                 conv_kernel_size: int = 31,
+                 activation: str = 'swish',
+                 use_attention: bool = True,
+                 use_convolution: bool = True,
+                 use_ffn_stream: bool = True,
+                 post_ffn: bool = True):
+        super().__init__()
+        self.pre_norm = nn.LayerNorm(hidden_dim)
+        self.use_attention = use_attention
+        self.use_convolution = use_convolution
+        self.use_ffn_stream = use_ffn_stream
+        self.attn_stream = MultiHeadSelfAttentionModule(
+            hidden_dim,
+            num_heads=num_heads,
+            dropout=dropout,
+            use_layer_norm=False,
+        ) if use_attention else None
+        self.conv_stream = ConformerConvolutionModule(
+            hidden_dim,
+            kernel_size=conv_kernel_size,
+            dropout=dropout,
+            activation=activation,
+            use_layer_norm=False,
+        ) if use_convolution else None
+        self.ffn_stream = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+            use_layer_norm=False,
+        ) if use_ffn_stream else None
+        self.num_streams = sum([
+            1 if use_attention else 0,
+            1 if use_convolution else 0,
+            1 if use_ffn_stream else 0,
+        ])
+        self.gate_proj = nn.Linear(hidden_dim, self.num_streams) if self.num_streams > 1 else None
+        self.stream_dropout = nn.Dropout(dropout)
+        self.post_ffn = FeedForwardModule(
+            hidden_dim,
+            expansion_factor=expansion_factor,
+            dropout=dropout,
+            activation=activation,
+        ) if post_ffn else None
+        self.final_layer_norm = nn.LayerNorm(hidden_dim)
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None) -> Tensor:
+        residual = x
+        x_norm = self.pre_norm(x)
+        streams: List[Tensor] = []
+        if self.attn_stream is not None:
+            streams.append(self.attn_stream(x_norm, key_padding_mask=key_padding_mask))
+        if self.conv_stream is not None:
+            streams.append(self.conv_stream(x_norm))
+        if self.ffn_stream is not None:
+            streams.append(self.ffn_stream(x_norm))
+
+        if not streams:
+            mixed = torch.zeros_like(x)
+        elif len(streams) == 1:
+            mixed = streams[0]
+        else:
+            stacked = torch.stack(streams, dim=-1)  # (B, T, H, num_streams)
+            gate_logits = self.gate_proj(x_norm)
+            gate = torch.softmax(gate_logits, dim=-1).unsqueeze(-2)
+            mixed = (stacked * gate).sum(dim=-1)
+
+        mixed = self.stream_dropout(mixed)
+        x = residual + mixed
+
+        if self.post_ffn is not None:
+            x = x + self.post_ffn(x)
+
+        x = self.final_layer_norm(x)
+        return x
+
+
+class HybridEncoder(nn.Module):
+    def __init__(self,
+                 hidden_dim: int,
+                 block_settings: List[Dict[str, Any]],
+                 global_params: Optional[Dict[str, Any]] = None):
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.global_params = global_params or {}
+        self.blocks = nn.ModuleList([])
+        for setting in block_settings:
+            block_type = setting.get('type', 'conformer').lower()
+            layers = setting.get('layers', 1)
+            block_kwargs = dict(self.global_params)
+            block_kwargs.update(setting.get('params', {}))
+            for _ in range(layers):
+                block = self._create_block(block_type, block_kwargs)
+                self.blocks.append(block)
+
+    def _create_block(self, block_type: str, params: Dict[str, Any]) -> nn.Module:
+        common_args = dict(
+            hidden_dim=self.hidden_dim,
+            num_heads=params.get('num_heads', 4),
+            expansion_factor=params.get('expansion_factor', 4.0),
+            dropout=params.get('dropout', 0.1),
+            conv_kernel_size=params.get('conv_kernel_size', 31),
+            activation=params.get('activation', 'swish'),
+        )
+        if block_type == 'conformer':
+            return ConformerBlock(
+                **common_args,
+                use_macaron=params.get('use_macaron', True),
+                use_conv_module=params.get('use_conv_module', True),
+            )
+        if block_type == 'emformer':
+            return EmformerBlock(
+                **common_args,
+                chunk_size=params.get('chunk_size', 64),
+                left_context=params.get('left_context', 64),
+                right_context=params.get('right_context', 16),
+                use_conv_module=params.get('use_conv_module', True),
+            )
+        if block_type == 'branchformer':
+            return BranchformerBlock(
+                **common_args,
+                enable_attn_branch=params.get('enable_attn_branch', True),
+                enable_conv_branch=params.get('enable_conv_branch', True),
+                enable_ffn_branch=params.get('enable_ffn_branch', True),
+                branch_dropout=params.get('branch_dropout', 0.1),
+                post_ffn=params.get('post_ffn', True),
+            )
+        if block_type == 'zipformer':
+            return ZipformerBlock(
+                **common_args,
+                use_attention=params.get('use_attention', True),
+                use_convolution=params.get('use_convolution', True),
+                use_ffn_stream=params.get('use_ffn_stream', True),
+                post_ffn=params.get('post_ffn', True),
+            )
+        raise ValueError(f"Unsupported encoder block type: {block_type}")
+
+    def forward(self,
+                x: Tensor,
+                key_padding_mask: Optional[Tensor] = None) -> Tensor:
+        for block in self.blocks:
+            x = block(x, key_padding_mask=key_padding_mask)
+        return x
 
 class LocationLayer(nn.Module):
     def __init__(self, attention_n_filters, attention_kernel_size,

--- a/models.py
+++ b/models.py
@@ -1,9 +1,8 @@
 import math
 import torch
 from torch import nn
-from torch.nn import TransformerEncoder
 import torch.nn.functional as F
-from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
+from layers import MFCC, Attention, LinearNorm, ConvNorm, HybridEncoder
 
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
@@ -18,17 +17,56 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
+                 encoder_type='conformer',
+                 encoder_heads=4,
+                 encoder_dropout=0.1,
+                 encoder_ffn_expansion=4.0,
+                 encoder_conv_kernel_size=31,
+                 encoder_block_config=None,
+                 encoder_block_sequence=None,
     ):
         super().__init__()
         self.n_token = n_token
         self.n_down = 1
         self.to_mfcc = MFCC()
         self.init_cnn = ConvNorm(input_dim//2, hidden_dim, kernel_size=7, padding=3, stride=2)
-        self.cnns = nn.Sequential(
-            *[nn.Sequential(
-                ConvBlock(hidden_dim),
-                nn.GroupNorm(num_groups=1, num_channels=hidden_dim)
-            ) for n in range(n_layers)])
+        block_defaults = encoder_block_config or {}
+        if encoder_block_sequence is None:
+            encoder_block_sequence = [
+                {
+                    'type': encoder_type,
+                    'layers': n_layers,
+                }
+            ]
+        prepared_blocks = []
+        for block in encoder_block_sequence:
+            if isinstance(block, str):
+                block_entry = {'type': block, 'layers': 1, 'params': {}}
+            else:
+                block_entry = dict(block)
+            block_type = block_entry.get('type', encoder_type).lower()
+            if not block_entry.get('enabled', True):
+                continue
+            merged_params = dict(block_defaults.get(block_type, {}))
+            merged_params.update(block_entry.get('params', {}))
+            block_entry['params'] = merged_params
+            layers = int(block_entry.get('layers', 1))
+            if layers <= 0:
+                continue
+            block_entry['layers'] = layers
+            prepared_blocks.append(block_entry)
+
+        encoder_global_params = {
+            'num_heads': encoder_heads,
+            'dropout': encoder_dropout,
+            'expansion_factor': encoder_ffn_expansion,
+            'conv_kernel_size': encoder_conv_kernel_size,
+        }
+        self.encoder = HybridEncoder(
+            hidden_dim=hidden_dim,
+            block_settings=prepared_blocks,
+            global_params=encoder_global_params,
+        )
         self.projection = ConvNorm(hidden_dim, hidden_dim // 2)
         self.ctc_linear = nn.Sequential(
             LinearNorm(hidden_dim//2, hidden_dim),
@@ -43,7 +81,11 @@ class ASRCNN(nn.Module):
     def forward(self, x, src_key_padding_mask=None, text_input=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
+        x = x.transpose(1, 2)
+        if src_key_padding_mask is not None:
+            src_key_padding_mask = src_key_padding_mask.to(dtype=torch.bool)
+        x = self.encoder(x, key_padding_mask=src_key_padding_mask)
+        x = x.transpose(1, 2)
 
         x = self.projection(x)
         x = x.transpose(1, 2)
@@ -57,8 +99,9 @@ class ASRCNN(nn.Module):
     def get_feature(self, x):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
-        x = self.instance_norm(x)
+        x = x.transpose(1, 2)
+        x = self.encoder(x)
+        x = x.transpose(1, 2)
         x = self.projection(x)
         return x
 


### PR DESCRIPTION
## Summary
- replace the previous CNN stack with a configurable hybrid encoder that can compose Conformer, Emformer, Branchformer, and Zipformer style blocks
- add encoder configuration knobs to Configs/config.yml so individual block families and their optional components can be enabled or disabled per deployment needs
- implement the supporting feed-forward, attention, convolution, and hybrid encoder block modules used by the new architecture

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d2d94f8afc833286ce2aabdb198159