### PR TITLE
Add configurable feature extractors

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -25,6 +25,18 @@ model_params:
    token_embedding_dim: 512
    n_layers: 5
    location_kernel_size: 31
+   feature_extractor:
+     type: mfcc  # options: mfcc, log_mel, learnable_filterbank
+     mfcc:
+       n_mfcc: 40
+       n_mels: 80
+     log_mel:
+       n_mels: 80
+     learnable_filterbank:
+       n_mels: 80
+       n_filters: 40
+       init: dct
+       bias: false
 
 optimizer_params:
   lr: 0.0005

--- a/layers.py
+++ b/layers.py
@@ -6,6 +6,7 @@ from torch import Tensor
 import torch.nn.functional as F
 import torchaudio
 import torchaudio.functional as audio_F
+import warnings
 
 import random
 random.seed(0)
@@ -269,3 +270,68 @@ class MFCC(nn.Module):
         if unsqueezed:
             mfcc = mfcc.squeeze(0)
         return mfcc
+
+
+class LearnableFilterbank(nn.Module):
+    """Learnable linear projection over the mel dimension."""
+
+    def __init__(self,
+                 in_channels: int,
+                 out_channels: int,
+                 bias: bool = True,
+                 init_type: str = 'dct',
+                 norm: str = 'ortho'):
+        super().__init__()
+        if in_channels <= 0 or out_channels <= 0:
+            raise ValueError("in_channels and out_channels must be positive integers")
+
+        self.in_channels = int(in_channels)
+        self.out_channels = int(out_channels)
+        self.norm = norm
+        self.conv = nn.Conv1d(self.in_channels, self.out_channels, kernel_size=1, bias=bias)
+        self.reset_parameters(init_type)
+
+    def reset_parameters(self, init_type: str = 'dct'):
+        init_type = (init_type or '').lower()
+        if init_type == 'dct':
+            if self.out_channels > self.in_channels:
+                warnings.warn(
+                    "Cannot initialise learnable filterbank with DCT when "
+                    "out_channels > in_channels. Falling back to Kaiming uniform initialisation.")
+                nn.init.kaiming_uniform_(self.conv.weight, a=math.sqrt(5))
+                if self.conv.bias is not None:
+                    fan_in = self.in_channels
+                    bound = 1 / math.sqrt(fan_in)
+                    nn.init.uniform_(self.conv.bias, -bound, bound)
+            else:
+                dct_mat = audio_F.create_dct(self.out_channels, self.in_channels, self.norm)
+                with torch.no_grad():
+                    self.conv.weight.copy_(dct_mat.unsqueeze(-1))
+                    if self.conv.bias is not None:
+                        self.conv.bias.zero_()
+        elif init_type == 'identity':
+            with torch.no_grad():
+                self.conv.weight.zero_()
+                diag = torch.arange(min(self.out_channels, self.in_channels))
+                self.conv.weight[diag, diag, 0] = 1.0
+                if self.conv.bias is not None:
+                    self.conv.bias.zero_()
+        else:
+            nn.init.kaiming_uniform_(self.conv.weight, a=math.sqrt(5))
+            if self.conv.bias is not None:
+                fan_in = self.in_channels
+                bound = 1 / math.sqrt(fan_in)
+                nn.init.uniform_(self.conv.bias, -bound, bound)
+
+    def forward(self, mel_features: torch.Tensor) -> torch.Tensor:
+        unsqueezed = False
+        if mel_features.dim() == 2:
+            mel_features = mel_features.unsqueeze(0)
+            unsqueezed = True
+
+        projected = self.conv(mel_features)
+
+        if unsqueezed:
+            projected = projected.squeeze(0)
+
+        return projected

--- a/models.py
+++ b/models.py
@@ -3,7 +3,58 @@ import torch
 from torch import nn
 from torch.nn import TransformerEncoder
 import torch.nn.functional as F
-from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
+from typing import Tuple, Dict, Any
+from layers import MFCC, LearnableFilterbank, Attention, LinearNorm, ConvNorm, ConvBlock
+
+
+def _build_feature_extractor(input_dim: int,
+                             feature_config: Dict[str, Any] = None) -> Tuple[nn.Module, int, str]:
+    if feature_config is None:
+        feature_config = {}
+
+    if isinstance(feature_config, str):
+        feature_config = {'type': feature_config}
+
+    feature_type = feature_config.get('type', 'mfcc')
+    if not isinstance(feature_type, str):
+        raise ValueError("feature_extractor 'type' must be a string")
+    feature_type = feature_type.lower()
+
+    if feature_type == 'mfcc':
+        mfcc_cfg = feature_config.get('mfcc', {}) or {}
+        n_mels = int(mfcc_cfg.get('n_mels', input_dim))
+        n_mfcc = int(mfcc_cfg.get('n_mfcc', max(1, n_mels // 2)))
+        feature_module = MFCC(n_mfcc=n_mfcc, n_mels=n_mels)
+        feature_dim = n_mfcc
+    elif feature_type == 'log_mel':
+        log_cfg = feature_config.get('log_mel', {}) or {}
+        expected_mels = int(log_cfg.get('n_mels', input_dim))
+        if expected_mels != input_dim:
+            raise ValueError(
+                f"Log-mel feature extractor expects input_dim ({input_dim}) to match the number of mel bins "
+                f"({expected_mels}). Please update the configuration to keep them in sync.")
+        feature_module = nn.Identity()
+        feature_dim = expected_mels
+    elif feature_type == 'learnable_filterbank':
+        fb_cfg = feature_config.get('learnable_filterbank', {}) or {}
+        n_mels = int(fb_cfg.get('n_mels', input_dim))
+        if n_mels != input_dim:
+            raise ValueError(
+                f"Learnable filterbank expects input_dim ({input_dim}) to match the configured number of mel bins "
+                f"({n_mels}). Please update the configuration to keep them in sync.")
+        n_filters = int(fb_cfg.get('n_filters', n_mels))
+        init_type = fb_cfg.get('init', 'dct')
+        bias = bool(fb_cfg.get('bias', True))
+        feature_module = LearnableFilterbank(
+            in_channels=n_mels,
+            out_channels=n_filters,
+            bias=bias,
+            init_type=init_type)
+        feature_dim = n_filters
+    else:
+        raise ValueError(f"Unsupported feature extractor type: {feature_type}")
+
+    return feature_module, feature_dim, feature_type
 
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
@@ -18,12 +69,17 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
+                 feature_extractor=None,
     ):
         super().__init__()
         self.n_token = n_token
         self.n_down = 1
-        self.to_mfcc = MFCC()
-        self.init_cnn = ConvNorm(input_dim//2, hidden_dim, kernel_size=7, padding=3, stride=2)
+        self.feature_extractor, feature_dim, feature_type = _build_feature_extractor(
+            input_dim=input_dim,
+            feature_config=feature_extractor)
+        self.feature_type = feature_type
+        self.feature_dim = feature_dim
+        self.init_cnn = ConvNorm(feature_dim, hidden_dim, kernel_size=7, padding=3, stride=2)
         self.cnns = nn.Sequential(
             *[nn.Sequential(
                 ConvBlock(hidden_dim),
@@ -41,7 +97,7 @@ class ASRCNN(nn.Module):
             location_kernel_size=location_kernel_size)
 
     def forward(self, x, src_key_padding_mask=None, text_input=None):
-        x = self.to_mfcc(x)
+        x = self.feature_extractor(x)
         x = self.init_cnn(x)
         x = self.cnns(x)
 
@@ -55,7 +111,7 @@ class ASRCNN(nn.Module):
             return ctc_logit
 
     def get_feature(self, x):
-        x = self.to_mfcc(x)
+        x = self.feature_extractor(x)
         x = self.init_cnn(x)
         x = self.cnns(x)
         x = self.instance_norm(x)


### PR DESCRIPTION
## Summary
- make the acoustic front-end configurable via `feature_extractor` options in the main config
- add a learnable filterbank layer and allow direct log-mel consumption in the encoder
- wire the ASRCNN model to use the selected feature extractor and expose its dimensionality

## Testing
- python -m compileall models.py layers.py

------
https://chatgpt.com/codex/tasks/task_e_68d2f75663848332a8462b0111693477