### PR TITLE
Add optional variance adaptor duration predictor

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -21,6 +21,17 @@ model_params:
    hidden_dim: 256
    n_token: 80
    token_embedding_dim: 256
+   auxiliary_models:
+     variance_adaptor:
+       enabled: false
+       duration_predictor:
+         enabled: true
+         loss_weight: 0.1
+         kernel_size: 3
+         filter_size: 256
+         n_layers: 2
+         dropout: 0.1
+         detach_alignment_grad: true
 
 optimizer_params:
   lr: 0.0005

--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ python train.py --config_path ./Configs/config.yml
 ```
 Please specify the training and validation data in `config.yml` file. The data list format needs to be `filename.wav|label|speaker_number`, see [train_list.txt](https://github.com/yl4579/AuxiliaryASR/blob/main/Data/train_list.txt) as an example (a subset for LJSpeech). Note that `speaker_number` can just be `0` for ASR, but it is useful to set a meaningful number for TTS training (if you need to use this repo for StyleTTS). 
 
-Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take. However, please note that `batch_size = 64` will take around 10G GPU RAM. 
+Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take. However, please note that `batch_size = 64` will take around 10G GPU RAM.
+
+### Auxiliary variance adaptor
+To stabilise TTS alignment you can optionally enable a FastSpeech-style duration predictor that is trained from the attention alignment. Set the following options in `Configs/config.yml`:
+
+```yaml
+model_params:
+  auxiliary_models:
+    variance_adaptor:
+      enabled: true          # turn the adaptor on/off
+      duration_predictor:
+        enabled: true        # enable the duration head
+        loss_weight: 0.1     # weighting factor for the auxiliary loss
+        detach_alignment_grad: true  # prevent gradients flowing into the attention map
+```
+
+Further hyper-parameters such as `kernel_size`, `filter_size`, `n_layers`, and `dropout` control the duration predictor architecture. Set `enabled: false` for either `variance_adaptor` or `duration_predictor` to disable the auxiliary module.
 
 ### Languages
 This repo is set up for English with the [g2p_en](https://github.com/Kyubyong/g2p) package, but you can train it with other languages. If you would like to train for datasets in different languages, you will need to modify the [meldataset.py](https://github.com/yl4579/AuxiliaryASR/blob/main/meldataset.py#L86-L93) file (L86-93) with your own phonemizer. You also need to change the vocabulary file ([word_index_dict.txt](https://github.com/yl4579/AuxiliaryASR/blob/main/word_index_dict.txt)) and change `n_token` in `config.yml` to reflect the number of tokens. A recommended phonemizer for other languages is [phonemizer](https://github.com/bootphon/phonemizer).

--- a/models.py
+++ b/models.py
@@ -5,6 +5,49 @@ from torch.nn import TransformerEncoder
 import torch.nn.functional as F
 from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
 
+
+class DurationPredictor(nn.Module):
+    def __init__(self,
+                 hidden_size,
+                 filter_size=256,
+                 kernel_size=3,
+                 n_layers=2,
+                 dropout=0.1):
+        super().__init__()
+        self.conv_layers = nn.ModuleList()
+        self.norm_layers = nn.ModuleList()
+        self.dropout = nn.Dropout(dropout)
+
+        for i in range(n_layers):
+            in_channels = hidden_size if i == 0 else filter_size
+            padding = (kernel_size - 1) // 2
+            self.conv_layers.append(
+                nn.Conv1d(in_channels, filter_size, kernel_size, padding=padding))
+            self.norm_layers.append(nn.LayerNorm(filter_size))
+
+        self.linear_layer = nn.Linear(filter_size, 1)
+
+    def forward(self, hidden_states, mask=None):
+        if mask is not None and mask.size(1) != hidden_states.size(1):
+            mask = mask[:, :hidden_states.size(1)]
+        x = hidden_states.transpose(1, 2)
+        for conv, norm in zip(self.conv_layers, self.norm_layers):
+            x = conv(x)
+            x = torch.relu(x)
+            x = x.transpose(1, 2)
+            x = norm(x)
+            x = x.transpose(1, 2)
+            x = self.dropout(x)
+
+        x = x.transpose(1, 2)
+        x = self.linear_layer(x).squeeze(-1)
+
+        if mask is not None:
+            mask = mask.to(dtype=torch.bool, device=x.device)
+            x = x.masked_fill(mask, 0.0)
+
+        return x
+
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
     return model
@@ -17,7 +60,7 @@ class ASRCNN(nn.Module):
                  n_token=35,
                  n_layers=6,
                  token_embedding_dim=256,
-
+                 auxiliary_models=None,
     ):
         super().__init__()
         self.n_token = n_token
@@ -39,7 +82,22 @@ class ASRCNN(nn.Module):
             hidden_dim=hidden_dim//2,
             n_token=n_token)
 
-    def forward(self, x, src_key_padding_mask=None, text_input=None):
+        self.auxiliary_models_config = auxiliary_models or {}
+        variance_config = self.auxiliary_models_config.get('variance_adaptor', {})
+        self.use_variance_adaptor = variance_config.get('enabled', False)
+        duration_config = variance_config.get('duration_predictor', {})
+        self.use_duration_predictor = self.use_variance_adaptor and duration_config.get('enabled', True)
+        if self.use_duration_predictor:
+            self.duration_predictor = DurationPredictor(
+                hidden_size=hidden_dim//2,
+                filter_size=duration_config.get('filter_size', hidden_dim//2),
+                kernel_size=duration_config.get('kernel_size', 3),
+                n_layers=duration_config.get('n_layers', 2),
+                dropout=duration_config.get('dropout', 0.1))
+        else:
+            self.duration_predictor = None
+
+    def forward(self, x, src_key_padding_mask=None, text_input=None, text_mask=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
         x = self.cnns(x)
@@ -48,7 +106,17 @@ class ASRCNN(nn.Module):
         x = x.transpose(1, 2)
         ctc_logit = self.ctc_linear(x)
         if text_input is not None:
-            _, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
+            decoder_hidden, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
+            aux_outputs = {}
+            if self.use_duration_predictor:
+                duration_mask = text_mask
+                if duration_mask is None and text_input is not None:
+                    duration_mask = torch.zeros_like(text_input, dtype=torch.bool, device=text_input.device)
+                if duration_mask is not None:
+                    aux_outputs['duration_pred'] = self.duration_predictor(
+                        decoder_hidden[:, 1:, :], mask=duration_mask)
+            if aux_outputs:
+                return ctc_logit, s2s_logit, s2s_attn, aux_outputs
             return ctc_logit, s2s_logit, s2s_attn
         else:
             return ctc_logit

--- a/train.py
+++ b/train.py
@@ -85,6 +85,7 @@ def main(config_path):
                     criterion=criterion,
                     optimizer=optimizer,
                     scheduler=scheduler,
+                    config=config,
                     device=device,
                     train_dataloader=train_dataloader,
                     val_dataloader=val_dataloader,

--- a/trainer.py
+++ b/trainer.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import numpy as np
 import torch
 from torch import nn
+import torch.nn.functional as F
 from PIL import Image
 from tqdm import tqdm
 
@@ -42,7 +43,7 @@ class Trainer(object):
         self.scheduler = scheduler
         self.train_dataloader = train_dataloader
         self.val_dataloader = val_dataloader
-        self.config = config
+        self.config = config or {}
         self.device = device
         self.finish_train = False
         self.logger = logger
@@ -125,6 +126,79 @@ class Trainer(object):
         mask = torch.gt(mask+1, lengths.unsqueeze(1))
         return mask
 
+    def _get_duration_config(self):
+        aux_config = self.config.get('model_params', {}).get('auxiliary_models', {})
+        variance_config = aux_config.get('variance_adaptor', {})
+        enabled = variance_config.get('enabled', False)
+        duration_config = variance_config.get('duration_predictor', {})
+        duration_enabled = enabled and duration_config.get('enabled', True)
+        return duration_enabled, duration_config
+
+    def _compute_duration_targets(self, alignments, text_lengths, mel_lengths, detach=True):
+        if alignments is None:
+            return None
+        if detach:
+            alignments = alignments.detach()
+        batch_size = alignments.size(0)
+        max_text_len = alignments.size(1) - 1
+        durations = alignments.new_zeros((batch_size, max_text_len))
+        for idx in range(batch_size):
+            text_len = int(text_lengths[idx].item())
+            mel_len = int(mel_lengths[idx].item())
+            if text_len <= 0 or mel_len <= 0:
+                continue
+            attn = alignments[idx, 1:text_len+1, :mel_len]
+            if attn.numel() == 0:
+                continue
+            frame_to_token = torch.argmax(attn, dim=0)
+            counts = torch.zeros(text_len, device=attn.device, dtype=attn.dtype)
+            counts.scatter_add_(0, frame_to_token,
+                                torch.ones_like(frame_to_token, dtype=attn.dtype))
+            durations[idx, :text_len] = counts
+        return durations
+
+    def _compute_duration_loss(self, aux_outputs, alignments, text_mask, text_lengths, mel_lengths):
+        duration_enabled, duration_config = self._get_duration_config()
+        if not duration_enabled:
+            return None
+        if aux_outputs is None or 'duration_pred' not in aux_outputs:
+            return None
+        duration_pred = aux_outputs['duration_pred']
+        if duration_pred is None:
+            return None
+        if text_mask is None:
+            return None
+
+        duration_targets = self._compute_duration_targets(
+            alignments,
+            text_lengths,
+            mel_lengths,
+            detach=duration_config.get('detach_alignment_grad', True))
+        if duration_targets is None:
+            return None
+        duration_targets = duration_targets.to(device=duration_pred.device,
+                                              dtype=duration_pred.dtype)
+
+        duration_mask = text_mask.to(device=duration_pred.device, dtype=torch.bool)
+        if duration_pred.size(1) != duration_mask.size(1):
+            min_len = min(duration_pred.size(1), duration_mask.size(1))
+            duration_pred = duration_pred[:, :min_len]
+            duration_mask = duration_mask[:, :min_len]
+            duration_targets = duration_targets[:, :min_len]
+
+        valid_positions = ~duration_mask
+        if valid_positions.sum() == 0:
+            return None
+
+        duration_target_log = torch.log(duration_targets + 1.0)
+        duration_loss = F.mse_loss(
+            duration_pred.masked_select(valid_positions),
+            duration_target_log.masked_select(valid_positions))
+        weight = duration_config.get('loss_weight', 0.0)
+        if weight == 0.0:
+            return None
+        return duration_loss * weight
+
     def _get_lr(self):
         for param_group in self.optimizer.param_groups:
             lr = param_group['lr']
@@ -160,8 +234,16 @@ class Trainer(object):
             mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
         mel_mask = self.model.length_to_mask(mel_input_length)
         text_mask = self.model.length_to_mask(text_input_length)
-        ppgs, s2s_pred, s2s_attn = self.model(
-            mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+        model_outputs = self.model(
+            mel_input,
+            src_key_padding_mask=mel_mask,
+            text_input=text_input,
+            text_mask=text_mask)
+        aux_outputs = {}
+        if isinstance(model_outputs, tuple) and len(model_outputs) == 4:
+            ppgs, s2s_pred, s2s_attn, aux_outputs = model_outputs
+        else:
+            ppgs, s2s_pred, s2s_attn = model_outputs
         
         loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
                                       text_input, mel_input_length, text_input_length)
@@ -172,13 +254,30 @@ class Trainer(object):
         loss_s2s /= text_input.size(0)
 
         loss = loss_ctc + loss_s2s
+
+        aux_losses = {}
+        duration_loss = self._compute_duration_loss(
+            aux_outputs,
+            s2s_attn,
+            text_mask,
+            text_input_length,
+            mel_input_length)
+        if duration_loss is not None:
+            aux_losses['duration'] = duration_loss
+
+        for value in aux_losses.values():
+            loss = loss + value
+
         loss.backward()
         torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
         self.optimizer.step()
         self.scheduler.step()
-        return {'loss': loss.item(),
-                'ctc': loss_ctc.item(),
-                's2s': loss_s2s.item()}
+        results = {'loss': loss.item(),
+                   'ctc': loss_ctc.item(),
+                   's2s': loss_s2s.item()}
+        for key, value in aux_losses.items():
+            results[f'aux/{key}'] = value.item()
+        return results
 
     def _train_epoch(self):
         train_losses = defaultdict(list)
@@ -205,8 +304,16 @@ class Trainer(object):
                 mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
             mel_mask = self.model.length_to_mask(mel_input_length)
             text_mask = self.model.length_to_mask(text_input_length)
-            ppgs, s2s_pred, s2s_attn = self.model(
-                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+            model_outputs = self.model(
+                mel_input,
+                src_key_padding_mask=mel_mask,
+                text_input=text_input,
+                text_mask=text_mask)
+            aux_outputs = {}
+            if isinstance(model_outputs, tuple) and len(model_outputs) == 4:
+                ppgs, s2s_pred, s2s_attn, aux_outputs = model_outputs
+            else:
+                ppgs, s2s_pred, s2s_attn = model_outputs
             loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
                                           text_input, mel_input_length, text_input_length)
             loss_s2s = 0
@@ -214,6 +321,16 @@ class Trainer(object):
                 loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
             loss_s2s /= text_input.size(0)
             loss = loss_ctc + loss_s2s
+
+            duration_loss = self._compute_duration_loss(
+                aux_outputs,
+                s2s_attn,
+                text_mask,
+                text_input_length,
+                mel_input_length)
+            if duration_loss is not None:
+                loss = loss + duration_loss
+                eval_losses["eval/aux_duration"].append(duration_loss.item())
 
             eval_losses["eval/ctc"].append(loss_ctc.item())
             eval_losses["eval/s2s"].append(loss_s2s.item())


### PR DESCRIPTION
## Summary
- add configuration switches for the optional variance adaptor duration predictor
- integrate the FastSpeech-style duration module and auxiliary loss into the trainer
- document how to enable and tune the adaptor in the README

## Testing
- python -m compileall models.py trainer.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d4358982fc8332bb9eeb7ac2e7aabe