### PR TITLE
Add configurable variance adaptor for duration alignment

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -67,3 +67,18 @@ dataloader_params:
 loss_weights:
   ctc: 0.8
   s2s: 1.0
+  duration: 0.0
+
+auxiliary_alignment:
+  variance_adaptor:
+    enabled: false
+    filter_size: 256
+    kernel_size: 3
+    dropout: 0.5
+    num_layers: 2
+    predict_log_duration: true
+  duration_loss:
+    enabled: false
+    target_strategy: uniform  # options: uniform, uniform_rounded, attention_peaks
+    log_target: true
+    mask_padding: true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,33 @@ loss_weights:
 
 Increasing the warm-up ratio (`optimizer_params.pct_start`) or reducing the batch size can also help when the number of training utterances is limited.
 
+### Auxiliary variance adaptor for alignment
+
+For TTS alignment use cases you can enable an auxiliary FastSpeech-style variance adaptor that predicts token durations from the decoder embeddings. This stabilizes attention learning by providing an extra supervision signal. Configure it from `Configs/config.yml`:
+
+```yaml
+model_params:
+  variance_adaptor:
+    enabled: true           # instantiate the duration predictor
+    filter_size: 256        # convolution width inside the predictor
+    kernel_size: 3
+    dropout: 0.5
+    num_layers: 2
+    predict_log_duration: true
+
+loss_weights:
+  duration: 0.2             # weight of the auxiliary duration loss
+
+auxiliary_alignment:
+  duration_loss:
+    enabled: true           # toggle the auxiliary loss without touching weights
+    target_strategy: uniform  # or uniform_rounded / attention_peaks
+    log_target: true         # compare in the log-domain (recommended)
+    mask_padding: true       # ignore padded tokens when computing the loss
+```
+
+The uniform target strategy distributes the acoustic frames evenly across phonemes, while `attention_peaks` derives coarse durations from the decoder attention map. You can disable the adaptor entirely by setting `variance_adaptor.enabled` to `false` or keep it enabled while zeroing out the loss weight for diagnostics.
+
 ### Languages
 This repo is set up for English with the [phonemizer](https://github.com/bootphon/phonemizer) package and espeak-ng backend. You can train it with other languages. If you would like to train for datasets in different languages, you will need to change the vocabulary file ([word_index_dict.txt](https://github.com/martinambrus/AuxiliaryASR/blob/main/word_index_dict.txt)) to contain the phonemes in your dataset. There is a utility script ([words_index_extractor.py](https://github.com/martinambrus/AuxiliaryASR/blob/main/words_index_extractor.py)) which will generate (and **_rewrite_**!) the file words_index_dict.txt when ran. Here's the syntax to use to generate this file:
 ```bash

--- a/layers.py
+++ b/layers.py
@@ -207,6 +207,102 @@ class Attention(nn.Module):
 
         return attention_context, attention_weights
 
+
+class DurationPredictor(nn.Module):
+    """Predicts token-level durations following the FastSpeech design."""
+
+    def __init__(
+            self,
+            in_dim: int,
+            filter_size: int = 256,
+            kernel_size: int = 3,
+            dropout: float = 0.5,
+            num_layers: int = 2,
+    ) -> None:
+        super().__init__()
+
+        self.conv_layers = nn.ModuleList()
+        self.layer_norms = nn.ModuleList()
+        self.dropouts = nn.ModuleList()
+
+        conv_in_channels = in_dim
+        padding = (kernel_size - 1) // 2
+        for _ in range(num_layers):
+            conv = nn.Conv1d(
+                conv_in_channels,
+                filter_size,
+                kernel_size,
+                padding=padding,
+            )
+            nn.init.xavier_uniform_(conv.weight)
+            self.conv_layers.append(conv)
+            self.layer_norms.append(nn.LayerNorm(filter_size))
+            self.dropouts.append(nn.Dropout(dropout))
+            conv_in_channels = filter_size
+
+        self.projection = nn.Linear(filter_size, 1)
+
+    def forward(self, encoder_output: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Compute duration predictions.
+
+        Args:
+            encoder_output: Tensor with shape ``(B, T, C)``.
+            mask: Optional boolean tensor of shape ``(B, T)`` where ``True`` marks padding positions.
+
+        Returns:
+            Tensor with shape ``(B, T)`` containing duration predictions.
+        """
+
+        x = encoder_output.transpose(1, 2)  # (B, C, T)
+        if mask is not None:
+            x = x.masked_fill(mask.unsqueeze(1), 0.0)
+
+        for conv, layer_norm, dropout in zip(self.conv_layers, self.layer_norms, self.dropouts):
+            x = conv(x)
+            x = F.relu(x)
+            x = x.transpose(1, 2)
+            x = layer_norm(x)
+            x = x.transpose(1, 2)
+            x = dropout(x)
+
+        x = x.transpose(1, 2)
+        x = self.projection(x)
+        durations = x.squeeze(-1)
+
+        if mask is not None:
+            durations = durations.masked_fill(mask, 0.0)
+
+        return durations
+
+
+class VarianceAdaptor(nn.Module):
+    """Auxiliary variance adaptor used for duration modelling."""
+
+    def __init__(
+            self,
+            input_dim: int,
+            filter_size: int = 256,
+            kernel_size: int = 3,
+            dropout: float = 0.5,
+            num_layers: int = 2,
+            predict_log_duration: bool = True,
+    ) -> None:
+        super().__init__()
+        self.predict_log_duration = predict_log_duration
+        self.duration_predictor = DurationPredictor(
+            input_dim,
+            filter_size=filter_size,
+            kernel_size=kernel_size,
+            dropout=dropout,
+            num_layers=num_layers,
+        )
+
+    def forward(self, encoder_output: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        durations = self.duration_predictor(encoder_output, mask=mask)
+        if self.predict_log_duration:
+            return durations
+        return F.softplus(durations)
+
 class PhaseShuffle2d(nn.Module):
     def __init__(self, n=2):
         super(PhaseShuffle2d, self).__init__()

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn
 from torch.nn import TransformerEncoder
 import torch.nn.functional as F
-from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
+from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock, VarianceAdaptor
 
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
@@ -18,6 +18,7 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
+                 variance_adaptor=None,
     ):
         super().__init__()
         self.n_token = n_token
@@ -34,13 +35,17 @@ class ASRCNN(nn.Module):
             LinearNorm(hidden_dim//2, hidden_dim),
             nn.ReLU(),
             LinearNorm(hidden_dim, n_token))
+        variance_adaptor = variance_adaptor or {}
         self.asr_s2s = ASRS2S(
             embedding_dim=token_embedding_dim,
             hidden_dim=hidden_dim//2,
             n_token=n_token,
-            location_kernel_size=location_kernel_size)
+            location_kernel_size=location_kernel_size,
+            variance_adaptor_config=variance_adaptor)
+        self.has_variance_adaptor = getattr(self.asr_s2s, 'has_variance_adaptor', False)
+        self.predicts_log_duration = getattr(self.asr_s2s, 'predicts_log_duration', False)
 
-    def forward(self, x, src_key_padding_mask=None, text_input=None):
+    def forward(self, x, src_key_padding_mask=None, text_input=None, text_mask=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
         x = self.cnns(x)
@@ -49,7 +54,14 @@ class ASRCNN(nn.Module):
         x = x.transpose(1, 2)
         ctc_logit = self.ctc_linear(x)
         if text_input is not None:
-            _, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
+            _, s2s_logit, s2s_attn, duration_pred = self.asr_s2s(
+                x,
+                src_key_padding_mask,
+                text_input,
+                text_mask=text_mask,
+            )
+            if self.has_variance_adaptor:
+                return ctc_logit, s2s_logit, s2s_attn, duration_pred
             return ctc_logit, s2s_logit, s2s_attn
         else:
             return ctc_logit
@@ -90,7 +102,8 @@ class ASRS2S(nn.Module):
                  hidden_dim=512,
                  n_location_filters=32,
                  location_kernel_size=63,
-                 n_token=40):
+                 n_token=40,
+                 variance_adaptor_config=None):
         super(ASRS2S, self).__init__()
         self.embedding = nn.Embedding(n_token, embedding_dim)
         val_range = math.sqrt(6 / hidden_dim)
@@ -111,6 +124,21 @@ class ASRS2S(nn.Module):
             nn.Tanh())
         self.sos = 1
         self.eos = 2
+        variance_adaptor_config = variance_adaptor_config or {}
+        self.has_variance_adaptor = bool(variance_adaptor_config.get('enabled', False))
+        self.predicts_log_duration = False
+        if self.has_variance_adaptor:
+            self.variance_adaptor = VarianceAdaptor(
+                embedding_dim,
+                filter_size=variance_adaptor_config.get('filter_size', 256),
+                kernel_size=variance_adaptor_config.get('kernel_size', 3),
+                dropout=variance_adaptor_config.get('dropout', 0.5),
+                num_layers=variance_adaptor_config.get('num_layers', 2),
+                predict_log_duration=variance_adaptor_config.get('predict_log_duration', True),
+            )
+            self.predicts_log_duration = self.variance_adaptor.predict_log_duration
+        else:
+            self.variance_adaptor = None
 
     def initialize_decoder_states(self, memory, mask):
         """
@@ -128,13 +156,19 @@ class ASRS2S(nn.Module):
         self.unk_index = 3
         self.random_mask = 0.1
 
-    def forward(self, memory, memory_mask, text_input):
+    def forward(self, memory, memory_mask, text_input, text_mask=None):
         """
         moemory.shape = (B, L, H) = (Batchsize, Maxtimestep, Hiddendim)
         moemory_mask.shape = (B, L, )
         texts_input.shape = (B, T)
         """
         self.initialize_decoder_states(memory, memory_mask)
+        duration_predictions = None
+        if self.has_variance_adaptor:
+            duration_predictions = self.variance_adaptor(
+                self.embedding(text_input),
+                mask=text_mask,
+            )
         # text random mask
         if self.training and self.random_mask > 0:
             random_mask = (torch.rand(text_input.shape, device=text_input.device) < self.random_mask)
@@ -160,7 +194,7 @@ class ASRS2S(nn.Module):
             self.parse_decoder_outputs(
                 hidden_outputs, logit_outputs, alignments)
 
-        return hidden_outputs, logit_outputs, alignments
+        return hidden_outputs, logit_outputs, alignments, duration_predictions
 
 
     def decode(self, decoder_input):

--- a/train.py
+++ b/train.py
@@ -295,6 +295,11 @@ def main(config_path):
     if not 'n_token' in model_params:
         model_params['n_token'] = len( word_indexes )
 
+    auxiliary_alignment_config = cfg_get_nested(config, 'auxiliary_alignment', {}) or {}
+    variance_adaptor_config = auxiliary_alignment_config.get('variance_adaptor', {}) or {}
+    if variance_adaptor_config.get('enabled', False):
+        model_params['variance_adaptor'] = variance_adaptor_config
+
     print("Using model parameters:", model_params)
 
     model = build_model(model_params=model_params)
@@ -325,6 +330,10 @@ def main(config_path):
     loss_weight_config = cfg_get_nested(config, 'loss_weights', {}) or {}
     ctc_weight = float(loss_weight_config.get('ctc', 1.0))
     s2s_weight = float(loss_weight_config.get('s2s', 1.0))
+    duration_weight = float(loss_weight_config.get('duration', 0.0))
+    duration_loss_config = auxiliary_alignment_config.get('duration_loss', {}) or {}
+    if not duration_loss_config.get('enabled', False):
+        duration_weight = 0.0
 
     trainer = Trainer(model=model,
                     criterion=criterion,
@@ -341,6 +350,10 @@ def main(config_path):
                     diagonal_attention_prior_weight=cfg_get_nested( config, 'diagonal_attention_prior_weight', 0.1),
                     ctc_weight=ctc_weight,
                     s2s_weight=s2s_weight,
+                    duration_loss_weight=duration_weight,
+                    duration_target_strategy=duration_loss_config.get('target_strategy', 'uniform'),
+                    log_duration_target=duration_loss_config.get('log_target', True),
+                    mask_duration_loss=duration_loss_config.get('mask_padding', True),
                     )
 
     pretrained_model = cfg_get_nested( config, 'pretrained_model', '' )

--- a/trainer.py
+++ b/trainer.py
@@ -39,7 +39,11 @@ class Trainer(object):
                  use_diagonal_attention_prior = True,
                  diagonal_attention_prior_weight = 0.1,
                  ctc_weight=1.0,
-                 s2s_weight=1.0):
+                 s2s_weight=1.0,
+                 duration_loss_weight=0.0,
+                 duration_target_strategy='uniform',
+                 log_duration_target=True,
+                 mask_duration_loss=True):
 
         self.steps = initial_steps
         self.epochs = initial_epochs
@@ -64,6 +68,15 @@ class Trainer(object):
         self.maxm_mem_usage = 0
         self.ctc_weight = ctc_weight
         self.s2s_weight = s2s_weight
+        self.duration_loss_weight = duration_loss_weight
+        self.duration_target_strategy = duration_target_strategy
+        self.log_duration_target = log_duration_target
+        self.mask_duration_loss = mask_duration_loss
+        self.duration_predicts_log = getattr(self.model, 'predicts_log_duration', False)
+        self.duration_loss_enabled = (
+            self.duration_loss_weight > 0.0 and getattr(self.model, 'has_variance_adaptor', False)
+        )
+        self.duration_loss_fn = nn.MSELoss(reduction='mean')
 
     def save_checkpoint(self, checkpoint_path):
         """Save checkpoint.
@@ -186,10 +199,21 @@ class Trainer(object):
         mel_input_length = mel_input_length // (2 ** self.model.n_down)
         future_mask = self.model.get_future_mask(
             mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
-        mel_mask = self.model.length_to_mask(mel_input_length)
-        text_mask = self.model.length_to_mask(text_input_length)
-        ppgs, s2s_pred, s2s_attn = self.model(
-            mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+        mel_mask = self.model.length_to_mask(mel_input_length).bool()
+        text_mask = self.model.length_to_mask(text_input_length).bool()
+        model_outputs = self.model(
+            mel_input,
+            src_key_padding_mask=mel_mask,
+            text_input=text_input,
+            text_mask=text_mask,
+        )
+        duration_pred = None
+        if isinstance(model_outputs, (list, tuple)) and len(model_outputs) >= 3:
+            ppgs, s2s_pred, s2s_attn = model_outputs[:3]
+            if len(model_outputs) > 3:
+                duration_pred = model_outputs[3]
+        else:
+            raise ValueError("Model forward must return at least three outputs when text_input is provided.")
 
         if self.use_diagonal_attention_prior:
             loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
@@ -202,7 +226,38 @@ class Trainer(object):
             loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
         loss_s2s /= text_input.size(0)
 
+        duration_loss = torch.tensor(0.0, device=self.device)
+        if self.duration_loss_enabled and duration_pred is not None:
+            duration_targets = self._build_duration_targets(
+                text_input_length,
+                mel_input_length,
+                text_mask,
+                alignments=s2s_attn if self.duration_target_strategy == 'attention_peaks' else None,
+            )
+            if self.log_duration_target:
+                duration_targets = torch.log(duration_targets + 1.0)
+
+            pred_for_loss = duration_pred
+            if self.duration_predicts_log and not self.log_duration_target:
+                pred_for_loss = torch.exp(duration_pred) - 1.0
+            elif (not self.duration_predicts_log) and self.log_duration_target:
+                pred_for_loss = torch.log(duration_pred + 1.0)
+
+            if self.mask_duration_loss:
+                valid_mask = ~text_mask
+                if valid_mask.any():
+                    duration_loss = self.duration_loss_fn(
+                        pred_for_loss.masked_select(valid_mask),
+                        duration_targets.masked_select(valid_mask),
+                    )
+                else:
+                    duration_loss = torch.tensor(0.0, device=self.device)
+            else:
+                duration_loss = self.duration_loss_fn(pred_for_loss, duration_targets)
+
         total_loss = self.ctc_weight * loss_ctc + self.s2s_weight * loss_s2s
+        if self.duration_loss_enabled:
+            total_loss = total_loss + self.duration_loss_weight * duration_loss
         if self.use_diagonal_attention_prior:
             total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
         loss = total_loss
@@ -210,9 +265,14 @@ class Trainer(object):
         torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
         self.optimizer.step()
         self.scheduler.step()
-        return {'loss': loss.item(),
-                'ctc': loss_ctc.item(),
-                's2s': loss_s2s.item()}
+        results = {
+            'loss': loss.item(),
+            'ctc': loss_ctc.item(),
+            's2s': loss_s2s.item(),
+        }
+        if self.duration_loss_enabled:
+            results['duration'] = duration_loss.item()
+        return results
 
     def _train_epoch(self):
         # switch dataloader if we're above configured epoch
@@ -254,10 +314,21 @@ class Trainer(object):
             mel_input_length = mel_input_length // (2 ** self.model.n_down)
             future_mask = self.model.get_future_mask(
                 mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
-            mel_mask = self.model.length_to_mask(mel_input_length)
-            text_mask = self.model.length_to_mask(text_input_length)
-            ppgs, s2s_pred, s2s_attn = self.model(
-                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+            mel_mask = self.model.length_to_mask(mel_input_length).bool()
+            text_mask = self.model.length_to_mask(text_input_length).bool()
+            model_outputs = self.model(
+                mel_input,
+                src_key_padding_mask=mel_mask,
+                text_input=text_input,
+                text_mask=text_mask,
+            )
+            duration_pred = None
+            if isinstance(model_outputs, (list, tuple)) and len(model_outputs) >= 3:
+                ppgs, s2s_pred, s2s_attn = model_outputs[:3]
+                if len(model_outputs) > 3:
+                    duration_pred = model_outputs[3]
+            else:
+                raise ValueError("Model forward must return at least three outputs when text_input is provided.")
             loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
                                           text_input, mel_input_length, text_input_length)
             loss_s2s = 0
@@ -266,9 +337,40 @@ class Trainer(object):
             loss_s2s /= text_input.size(0)
             loss = loss_ctc + loss_s2s
 
+            if self.duration_loss_enabled and duration_pred is not None:
+                duration_targets = self._build_duration_targets(
+                    text_input_length,
+                    mel_input_length,
+                    text_mask,
+                    alignments=s2s_attn if self.duration_target_strategy == 'attention_peaks' else None,
+                )
+                if self.log_duration_target:
+                    duration_targets = torch.log(duration_targets + 1.0)
+
+                pred_for_loss = duration_pred
+                if self.duration_predicts_log and not self.log_duration_target:
+                    pred_for_loss = torch.exp(duration_pred) - 1.0
+                elif (not self.duration_predicts_log) and self.log_duration_target:
+                    pred_for_loss = torch.log(duration_pred + 1.0)
+
+                if self.mask_duration_loss:
+                    valid_mask = ~text_mask
+                    if valid_mask.any():
+                        duration_loss = self.duration_loss_fn(
+                            pred_for_loss.masked_select(valid_mask),
+                            duration_targets.masked_select(valid_mask),
+                        )
+                    else:
+                        duration_loss = torch.tensor(0.0, device=self.device)
+                else:
+                    duration_loss = self.duration_loss_fn(pred_for_loss, duration_targets)
+                loss = loss + self.duration_loss_weight * duration_loss
+
             eval_losses["eval/ctc"].append(loss_ctc.item())
             eval_losses["eval/s2s"].append(loss_s2s.item())
             eval_losses["eval/loss"].append(loss.item())
+            if self.duration_loss_enabled and duration_pred is not None:
+                eval_losses["eval/duration"].append(duration_loss.item())
 
             _, amax_ppgs = torch.max(ppgs, dim=2)
             wers = [calc_wer(target[:text_length],
@@ -290,3 +392,58 @@ class Trainer(object):
         eval_losses = {key: np.mean(value) for key, value in eval_losses.items()}
         eval_losses.update(eval_images)
         return eval_losses
+
+    def _build_duration_targets(self, text_lengths, mel_lengths, text_mask, alignments=None):
+        batch_size = text_lengths.size(0)
+        max_text_len = text_mask.size(1)
+        device = text_lengths.device
+        durations = torch.zeros(batch_size, max_text_len, device=device, dtype=torch.float32)
+
+        for idx in range(batch_size):
+            text_len = int(text_lengths[idx].item())
+            mel_len = int(mel_lengths[idx].item())
+            if text_len <= 0 or mel_len <= 0:
+                continue
+
+            if self.duration_target_strategy == 'uniform_rounded':
+                base = mel_len // text_len
+                remainder = mel_len % text_len
+                durations[idx, :text_len] = float(base)
+                if remainder > 0:
+                    durations[idx, :remainder] += 1.0
+            elif self.duration_target_strategy == 'attention_peaks' and alignments is not None:
+                durations[idx, :text_len] = self._attention_peak_durations(
+                    alignments[idx], text_len, mel_len)
+            else:
+                durations[idx, :text_len] = float(mel_len) / float(text_len)
+
+        durations = torch.clamp(durations, min=1.0)
+        if self.mask_duration_loss:
+            durations = durations.masked_fill(text_mask, 0.0)
+        return durations
+
+    def _attention_peak_durations(self, alignment, text_len, mel_len):
+        if mel_len <= 0 or text_len <= 0:
+            return torch.zeros(text_len, device=alignment.device, dtype=torch.float32)
+
+        attn = alignment[1:text_len+1, :mel_len]
+        if attn.numel() == 0:
+            return torch.full((text_len,), float(mel_len) / max(text_len, 1),
+                              device=alignment.device, dtype=torch.float32)
+
+        peak_positions = torch.argmax(attn, dim=1).float()
+        for idx in range(1, peak_positions.size(0)):
+            peak_positions[idx] = torch.max(peak_positions[idx], peak_positions[idx - 1] + 1.0)
+        peak_positions = torch.clamp(peak_positions, max=float(mel_len - 1))
+
+        boundaries = torch.zeros(text_len + 1, device=alignment.device, dtype=torch.float32)
+        boundaries[-1] = float(mel_len)
+        for idx in range(1, text_len):
+            boundaries[idx] = (peak_positions[idx - 1] + peak_positions[idx]) / 2.0
+
+        durations = boundaries[1:] - boundaries[:-1]
+        durations = torch.clamp(durations, min=1.0)
+        total = durations.sum()
+        if total > 0:
+            durations = durations * (float(mel_len) / total)
+        return durations


### PR DESCRIPTION
## Summary
- add a FastSpeech-style variance adaptor and duration predictor modules
- expose configuration knobs in config.yml and Trainer for auxiliary duration loss
- document how to enable the auxiliary alignment features and allow runtime toggles

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d43954660083329af6583965b0a62a