### PR TITLE
Add FastSpeech-style variance adaptor and duration loss

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -25,6 +25,17 @@ model_params:
    token_embedding_dim: 512
    n_layers: 5
    location_kernel_size: 31
+   auxiliary_models:
+     variance_adaptor:
+       enabled: true
+       detach_attention_for_targets: true
+       loss_weight: 0.5
+       loss_type: "mse"  # options: mse, l1, smooth_l1
+       duration_predictor:
+         n_layers: 2
+         filter_size: 256
+         kernel_size: 3
+         dropout: 0.5
 
 optimizer_params:
   lr: 0.0005
@@ -67,3 +78,4 @@ dataloader_params:
 loss_weights:
   ctc: 0.8
   s2s: 1.0
+  variance_duration: 0.5

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "3258aa03",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "43655ce4",
@@ -112,6 +122,7 @@
     "def load_asr_model(model_path, config_path, device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -194,7 +205,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "bbb95884",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b60481c8",
@@ -114,6 +124,7 @@
     "def load_asr_model(model_path, config_path, device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -193,7 +204,27 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -9,6 +9,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "172c230a",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "84ce219e",
@@ -203,7 +213,27 @@
     "        device='cuda' if device.type == 'cuda' else 'cpu',\n",
     "        dataset_config=dataset_cfg,\n",
     "    )\n",
-    "    return loader, path_list\n"
+    "    return loader, path_list\n",
+    "\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "846f021d",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "check-cuda",
@@ -111,6 +121,7 @@
     "def load_asr_model(model_path, config_path, device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -192,7 +203,27 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c4bb27fc",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "f1ae7942",
@@ -101,6 +111,7 @@
     "def load_asr_model(model_path: str, config_path: str, device: torch.device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -186,7 +197,26 @@
     "    return loader\n",
     "\n",
     "NORMALIZATION_MEAN = -4.0\n",
-    "NORMALIZATION_STD = 4.0"
+    "NORMALIZATION_STD = 4.0\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -11,6 +11,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c7a94a80",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "77be9b72",
@@ -109,6 +119,7 @@
     "def load_asr_model(model_path, config_path, device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -189,7 +200,27 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -25,6 +25,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "11e0d233",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "db3a9b85",
@@ -95,6 +105,7 @@
     "def load_asr_model(model_path, config_path, device):\n",
     "    with open(config_path) as f:\n",
     "        config = yaml.safe_load(f)\n",
+    "        describe_variance_adapter(config)\n",
     "\n",
     "    token_map = load_token_map_from_config(config)\n",
     "\n",
@@ -177,7 +188,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -25,6 +25,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "60d4207c",
+   "metadata": {},
+   "source": [
+    "## Variance adaptor support\n",
+    "\n",
+    "This notebook now detects and exposes the optional FastSpeech-style variance adaptor. Use the `model_params.auxiliary_models.variance_adaptor` section in `Configs/config.yml` to enable or disable the duration predictor and to adjust its hyper-parameters."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "a30e5615-cae5-4e9e-a6f5-cf41aa100e28",
@@ -127,7 +137,27 @@
     "\n",
     "    asr_model = _load_model(model_params, ASR_MODEL_PATH)\n",
     "\n",
-    "    return asr_model\n"
+    "    return asr_model\n",
+    "\n",
+    "\n",
+    "\n",
+    "def describe_variance_adapter(config):\n",
+    "    variance_cfg = cfg_get_nested(config, \"model_params.auxiliary_models.variance_adaptor\", {})\n",
+    "    enabled = bool(variance_cfg.get(\"enabled\", False))\n",
+    "    print(f\"FastSpeech-style variance adaptor enabled: {enabled}\")\n",
+    "    if variance_cfg:\n",
+    "        loss_weight = variance_cfg.get(\"loss_weight\", \"n/a\")\n",
+    "        loss_type = variance_cfg.get(\"loss_type\", \"mse\")\n",
+    "        detach = variance_cfg.get(\"detach_attention_for_targets\", True)\n",
+    "        print(f\"  loss weight: {loss_weight}\")\n",
+    "        print(f\"  loss type: {loss_type}\")\n",
+    "        print(f\"  detach attention for targets: {detach}\")\n",
+    "        duration_cfg = variance_cfg.get(\"duration_predictor\", {}) or {}\n",
+    "        if duration_cfg:\n",
+    "            print(\"  duration predictor hyper-parameters:\")\n",
+    "            for key, value in duration_cfg.items():\n",
+    "                print(f\"    {key}: {value}\")\n",
+    "    return variance_cfg\n"
    ]
   },
   {

--- a/layers.py
+++ b/layers.py
@@ -130,6 +130,101 @@ class ConvBlock(nn.Module):
         ]
         return nn.Sequential(*layers)
 
+
+class DurationPredictor(nn.Module):
+    """Predict log-duration targets for variance adaptation."""
+
+    def __init__(self,
+                 input_size: int,
+                 filter_size: int = 256,
+                 kernel_size: int = 3,
+                 dropout: float = 0.5,
+                 n_layers: int = 2):
+        super().__init__()
+        if n_layers < 1:
+            raise ValueError("DurationPredictor requires at least one layer")
+
+        self.layers = nn.ModuleList()
+        for layer_index in range(n_layers):
+            in_channels = input_size if layer_index == 0 else filter_size
+            self.layers.append(nn.ModuleDict({
+                "conv": ConvNorm(in_channels,
+                                   filter_size,
+                                   kernel_size=kernel_size,
+                                   padding=(kernel_size - 1) // 2),
+                "activation": nn.ReLU(),
+                "layer_norm": nn.LayerNorm(filter_size),
+                "dropout": nn.Dropout(dropout)
+            }))
+
+        self.proj = LinearNorm(filter_size, 1)
+
+    def forward(self, x: Tensor, mask: Optional[Tensor] = None) -> Tensor:
+        """Forward pass.
+
+        Args:
+            x: Tensor of shape ``[B, T, C]`` containing hidden states.
+            mask: Optional bool tensor of shape ``[B, T]`` where ``True``
+                indicates padded positions.
+
+        Returns:
+            Tensor of shape ``[B, T]`` with log-duration predictions.
+        """
+
+        out = x
+        for layer in self.layers:
+            conv = layer["conv"]
+            activation = layer["activation"]
+            layer_norm = layer["layer_norm"]
+            dropout = layer["dropout"]
+
+            out = conv(out.transpose(1, 2)).transpose(1, 2)
+            out = activation(out)
+            out = layer_norm(out)
+            out = dropout(out)
+
+        out = self.proj(out).squeeze(-1)
+        if mask is not None:
+            out = out.masked_fill(mask, 0.0)
+        return out
+
+
+class VarianceAdaptor(nn.Module):
+    """FastSpeech-style variance adaptor supporting duration prediction."""
+
+    def __init__(self,
+                 input_size: int,
+                 duration_predictor_config: Optional[dict] = None):
+        super().__init__()
+        duration_predictor_config = duration_predictor_config or {}
+
+        self.duration_predictor = DurationPredictor(
+            input_size=input_size,
+            filter_size=int(duration_predictor_config.get("filter_size",
+                                                          input_size)),
+            kernel_size=int(duration_predictor_config.get("kernel_size", 3)),
+            dropout=float(duration_predictor_config.get("dropout", 0.5)),
+            n_layers=int(duration_predictor_config.get("n_layers", 2)),
+        )
+
+    def forward(self, x: Tensor, mask: Optional[Tensor] = None) -> dict:
+        """Predict auxiliary variance targets.
+
+        Args:
+            x: Decoder hidden states ``[B, T, C]``.
+            mask: Optional bool tensor ``[B, T]`` marking padding positions.
+
+        Returns:
+            Dictionary with ``log_duration`` and ``duration`` predictions.
+        """
+
+        log_duration = self.duration_predictor(x, mask=mask)
+        duration = torch.clamp(torch.exp(log_duration) - 1.0, min=0.0)
+        return {
+            "log_duration": log_duration,
+            "duration": duration,
+        }
+
 class LocationLayer(nn.Module):
     def __init__(self, attention_n_filters, attention_kernel_size,
                  attention_dim):

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ import torch
 from torch import nn
 from torch.nn import TransformerEncoder
 import torch.nn.functional as F
-from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
+from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock, VarianceAdaptor
 
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
@@ -18,6 +18,7 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
+                 auxiliary_models=None,
     ):
         super().__init__()
         self.n_token = n_token
@@ -40,6 +41,17 @@ class ASRCNN(nn.Module):
             n_token=n_token,
             location_kernel_size=location_kernel_size)
 
+        auxiliary_models = auxiliary_models or {}
+        variance_cfg = auxiliary_models.get('variance_adaptor', {})
+        self.use_variance_adaptor = bool(variance_cfg.get('enabled', False))
+        if self.use_variance_adaptor:
+            duration_predictor_cfg = variance_cfg.get('duration_predictor', {})
+            self.variance_adaptor = VarianceAdaptor(
+                input_size=self.asr_s2s.decoder_rnn_dim,
+                duration_predictor_config=duration_predictor_cfg)
+        else:
+            self.variance_adaptor = None
+
     def forward(self, x, src_key_padding_mask=None, text_input=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
@@ -49,8 +61,12 @@ class ASRCNN(nn.Module):
         x = x.transpose(1, 2)
         ctc_logit = self.ctc_linear(x)
         if text_input is not None:
-            _, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
-            return ctc_logit, s2s_logit, s2s_attn
+            hidden_states, s2s_logit, s2s_attn = self.asr_s2s(x, src_key_padding_mask, text_input)
+            auxiliary_outputs = {}
+            if self.use_variance_adaptor and self.variance_adaptor is not None:
+                decoder_hidden = hidden_states[:, 1:, :]
+                auxiliary_outputs = self.variance_adaptor(decoder_hidden)
+            return ctc_logit, s2s_logit, s2s_attn, auxiliary_outputs
         else:
             return ctc_logit
 

--- a/train.py
+++ b/train.py
@@ -294,6 +294,8 @@ def main(config_path):
 
     if not 'n_token' in model_params:
         model_params['n_token'] = len( word_indexes )
+    if 'auxiliary_models' not in model_params:
+        model_params['auxiliary_models'] = {}
 
     print("Using model parameters:", model_params)
 
@@ -325,6 +327,13 @@ def main(config_path):
     loss_weight_config = cfg_get_nested(config, 'loss_weights', {}) or {}
     ctc_weight = float(loss_weight_config.get('ctc', 1.0))
     s2s_weight = float(loss_weight_config.get('s2s', 1.0))
+    variance_cfg = cfg_get_nested(config, 'model_params.auxiliary_models.variance_adaptor', {}) or {}
+    use_variance_adaptor = bool(variance_cfg.get('enabled', False))
+    variance_loss_weight = float(variance_cfg.get('loss_weight', 1.0))
+    if 'variance_duration' in loss_weight_config:
+        variance_loss_weight = float(loss_weight_config['variance_duration'])
+    variance_loss_type = variance_cfg.get('loss_type', 'mse')
+    detach_duration_targets = bool(variance_cfg.get('detach_attention_for_targets', True))
 
     trainer = Trainer(model=model,
                     criterion=criterion,
@@ -341,6 +350,10 @@ def main(config_path):
                     diagonal_attention_prior_weight=cfg_get_nested( config, 'diagonal_attention_prior_weight', 0.1),
                     ctc_weight=ctc_weight,
                     s2s_weight=s2s_weight,
+                    use_variance_adaptor=use_variance_adaptor,
+                    variance_loss_weight=variance_loss_weight,
+                    variance_loss_type=variance_loss_type,
+                    detach_duration_targets=detach_duration_targets,
                     )
 
     pretrained_model = cfg_get_nested( config, 'pretrained_model', '' )

--- a/trainer.py
+++ b/trainer.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 import numpy as np
 import torch
 from torch import nn
+import torch.nn.functional as F
 from PIL import Image
 from tqdm import tqdm
 
@@ -39,7 +40,11 @@ class Trainer(object):
                  use_diagonal_attention_prior = True,
                  diagonal_attention_prior_weight = 0.1,
                  ctc_weight=1.0,
-                 s2s_weight=1.0):
+                 s2s_weight=1.0,
+                 use_variance_adaptor=False,
+                 variance_loss_weight=1.0,
+                 variance_loss_type='mse',
+                 detach_duration_targets=True):
 
         self.steps = initial_steps
         self.epochs = initial_epochs
@@ -64,6 +69,10 @@ class Trainer(object):
         self.maxm_mem_usage = 0
         self.ctc_weight = ctc_weight
         self.s2s_weight = s2s_weight
+        self.use_variance_adaptor = use_variance_adaptor
+        self.variance_loss_weight = variance_loss_weight
+        self.variance_loss_type = variance_loss_type
+        self.detach_duration_targets = detach_duration_targets
 
     def save_checkpoint(self, checkpoint_path):
         """Save checkpoint.
@@ -188,8 +197,13 @@ class Trainer(object):
             mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
         mel_mask = self.model.length_to_mask(mel_input_length)
         text_mask = self.model.length_to_mask(text_input_length)
-        ppgs, s2s_pred, s2s_attn = self.model(
+        model_outputs = self.model(
             mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+        if isinstance(model_outputs, (list, tuple)) and len(model_outputs) == 4:
+            ppgs, s2s_pred, s2s_attn, auxiliary_outputs = model_outputs
+        else:
+            ppgs, s2s_pred, s2s_attn = model_outputs
+            auxiliary_outputs = {}
 
         if self.use_diagonal_attention_prior:
             loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
@@ -202,17 +216,37 @@ class Trainer(object):
             loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
         loss_s2s /= text_input.size(0)
 
+        duration_loss = torch.tensor(0.0, device=self.device)
+        if self.use_variance_adaptor and auxiliary_outputs:
+            log_duration_pred = auxiliary_outputs.get('log_duration')
+            if log_duration_pred is not None:
+                attn_for_duration = s2s_attn.detach() if self.detach_duration_targets else s2s_attn
+                duration_targets = self._compute_duration_targets(
+                    attn_for_duration,
+                    text_input_length,
+                    mel_input_length)
+                log_duration_target = torch.log1p(duration_targets)
+                duration_loss = self._duration_loss(
+                    log_duration_pred,
+                    log_duration_target,
+                    text_input_length)
+
         total_loss = self.ctc_weight * loss_ctc + self.s2s_weight * loss_s2s
         if self.use_diagonal_attention_prior:
             total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
+        if self.use_variance_adaptor and auxiliary_outputs:
+            total_loss = total_loss + self.variance_loss_weight * duration_loss
         loss = total_loss
         loss.backward()
         torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
         self.optimizer.step()
         self.scheduler.step()
-        return {'loss': loss.item(),
-                'ctc': loss_ctc.item(),
-                's2s': loss_s2s.item()}
+        results = {'loss': loss.item(),
+                   'ctc': loss_ctc.item(),
+                   's2s': loss_s2s.item()}
+        if self.use_variance_adaptor and auxiliary_outputs:
+            results['duration'] = duration_loss.item()
+        return results
 
     def _train_epoch(self):
         # switch dataloader if we're above configured epoch
@@ -256,19 +290,41 @@ class Trainer(object):
                 mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
             mel_mask = self.model.length_to_mask(mel_input_length)
             text_mask = self.model.length_to_mask(text_input_length)
-            ppgs, s2s_pred, s2s_attn = self.model(
+            model_outputs = self.model(
                 mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+            if isinstance(model_outputs, (list, tuple)) and len(model_outputs) == 4:
+                ppgs, s2s_pred, s2s_attn, auxiliary_outputs = model_outputs
+            else:
+                ppgs, s2s_pred, s2s_attn = model_outputs
+                auxiliary_outputs = {}
             loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
                                           text_input, mel_input_length, text_input_length)
             loss_s2s = 0
             for _s2s_pred, _text_input, _text_length in zip(s2s_pred, text_input, text_input_length):
                 loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
             loss_s2s /= text_input.size(0)
+            duration_loss = torch.tensor(0.0, device=self.device)
+            if self.use_variance_adaptor and auxiliary_outputs:
+                log_duration_pred = auxiliary_outputs.get('log_duration')
+                if log_duration_pred is not None:
+                    duration_targets = self._compute_duration_targets(
+                        s2s_attn.detach(),
+                        text_input_length,
+                        mel_input_length)
+                    log_duration_target = torch.log1p(duration_targets)
+                    duration_loss = self._duration_loss(
+                        log_duration_pred,
+                        log_duration_target,
+                        text_input_length)
             loss = loss_ctc + loss_s2s
+            if self.use_variance_adaptor and auxiliary_outputs:
+                loss = loss + self.variance_loss_weight * duration_loss
 
             eval_losses["eval/ctc"].append(loss_ctc.item())
             eval_losses["eval/s2s"].append(loss_s2s.item())
             eval_losses["eval/loss"].append(loss.item())
+            if self.use_variance_adaptor and auxiliary_outputs:
+                eval_losses["eval/duration"].append(duration_loss.item())
 
             _, amax_ppgs = torch.max(ppgs, dim=2)
             wers = [calc_wer(target[:text_length],
@@ -290,3 +346,43 @@ class Trainer(object):
         eval_losses = {key: np.mean(value) for key, value in eval_losses.items()}
         eval_losses.update(eval_images)
         return eval_losses
+
+    def _compute_duration_targets(self, attn, text_lengths, mel_lengths):
+        """Convert attention maps into discrete duration targets."""
+        batch_size = attn.size(0)
+        max_text_len = int(text_lengths.max().item()) if text_lengths.numel() else 0
+        device = attn.device
+        durations = attn.new_zeros((batch_size, max_text_len))
+
+        for idx in range(batch_size):
+            text_len = int(text_lengths[idx].item())
+            mel_len = int(mel_lengths[idx].item())
+            if text_len == 0 or mel_len == 0:
+                continue
+            attn_slice = attn[idx, 1:1 + text_len, :mel_len]
+            if attn_slice.numel() == 0:
+                continue
+            frame_assignments = attn_slice.argmax(dim=0)
+            counts = torch.bincount(frame_assignments, minlength=text_len).float().to(device)
+            durations[idx, :text_len] = counts
+
+        return durations
+
+    def _duration_loss(self, log_duration_pred, log_duration_target, text_lengths):
+        """Compute masked error between predicted and target log durations."""
+        if log_duration_pred.dim() == 3 and log_duration_pred.size(-1) == 1:
+            log_duration_pred = log_duration_pred.squeeze(-1)
+
+        mask = self.length_to_mask(text_lengths).to(log_duration_pred.device)
+        mask = mask[:, :log_duration_pred.size(1)]
+
+        if self.variance_loss_type == 'l1':
+            loss = torch.abs(log_duration_pred - log_duration_target)
+        elif self.variance_loss_type in ('smooth_l1', 'huber'):
+            loss = F.smooth_l1_loss(log_duration_pred, log_duration_target, reduction='none')
+        else:
+            loss = (log_duration_pred - log_duration_target) ** 2
+
+        loss = loss.masked_fill(mask, 0.0)
+        denom = torch.clamp((~mask).sum(), min=1).float()
+        return loss.sum() / denom


### PR DESCRIPTION
## Summary
- add a FastSpeech-style variance adaptor with an auxiliary duration predictor to the ASR model and expose its toggles via config
- extend the trainer with attention-derived duration targets, configurable auxiliary loss weighting, and updated optimizer wiring
- refresh utility notebooks to surface the new variance adaptor configuration when loading models

## Testing
- python -m compileall models.py trainer.py layers.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d446e4b34c8332b5cc7daa0989b4e0