### PR TITLE
Add stabilization options for deeper encoder training

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -40,6 +40,25 @@ multi_task:
     enabled: false
     num_classes: 2  # set to the number of pronunciation error categories your dataset annotates
 
+stabilization:
+  stochastic_depth:
+    enabled: false
+    max_drop_rate: 0.15
+    min_drop_rate: 0.0
+    mode: linear  # options: linear, uniform
+  mix_speech:
+    enabled: false
+    alpha: 0.3
+    prob: 0.5
+    dominant_mix: true
+  intermediate_ctc:
+    enabled: false
+    loss_weight: 0.3
+    dropout: 0.1
+    layers:
+      - index: 3
+        weight: 1.0
+
 optimizer_params:
   lr: 0.0005
   pct_start: 0.1
@@ -84,3 +103,4 @@ loss_weights:
   frame_phoneme: 0.0
   speaker: 0.0
   pronunciation_error: 0.0
+  intermediate_ctc: 0.0

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -135,6 +135,8 @@
     "    if 'n_token' not in model_params:\n",
     "        model_params['n_token'] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)\n",
     "    state_dict = checkpoint.get('model', checkpoint)\n",

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -137,6 +137,8 @@
     "    if \"n_token\" not in model_params:\n",
     "        model_params[\"n_token\"] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location=\"cpu\", weights_only=False)\n",
     "    state_dict = checkpoint.get(\"model\", checkpoint)\n",

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -125,6 +125,8 @@
     "    if 'n_token' not in model_params:\n",
     "        model_params['n_token'] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)\n",
     "    state_dict = checkpoint.get('model', checkpoint)\n",

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -134,6 +134,8 @@
     "    if 'n_token' not in model_params:\n",
     "        model_params['n_token'] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)\n",
     "    state_dict = checkpoint.get('model', checkpoint)\n",

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -124,6 +124,8 @@
     "    if \"n_token\" not in model_params:\n",
     "        model_params[\"n_token\"] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location=\"cpu\", weights_only=False)\n",
     "    state_dict = checkpoint.get(\"model\", checkpoint)\n",

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -132,6 +132,8 @@
     "    if 'n_token' not in model_params:\n",
     "        model_params['n_token'] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)\n",
     "    state_dict = checkpoint.get('model', checkpoint)\n",

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -118,6 +118,8 @@
     "    if 'n_token' not in model_params:\n",
     "        model_params['n_token'] = len(token_map)\n",
     "\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
+    "\n",
     "    model = ASRCNN(**model_params)\n",
     "    checkpoint = torch.load(model_path, map_location='cpu', weights_only=False)\n",
     "    state_dict = checkpoint.get('model', checkpoint)\n",

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -138,6 +138,7 @@
     "        model_params = dict(default_model_params)\n",
     "\n",
     "    model_params.setdefault('n_token', len(token_map))\n",
+    "    model_params.setdefault('stabilization_config', cfg_get_nested(config, 'stabilization', {}))\n",
     "\n",
     "    multi_task_config = cfg_get_nested(config, 'multi_task', {}) or {}\n",
     "    model_params['multi_task_config'] = multi_task_config\n",
@@ -185,7 +186,7 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK \u2713\")\n"
+    "print( \"All OK ✓\")\n"
    ]
   },
   {
@@ -419,7 +420,7 @@
     "    predictions_cleaned = [' '.join(seq) for seq in predictions]\n",
     "    per = wer(references_cleaned, predictions_cleaned)\n",
     "\n",
-    "    print(f'Phoneme Error Rate: {per:.4f} {\"\u2713\" if per < best_model_per else \"\u2717\"}')\n",
+    "    print(f'Phoneme Error Rate: {per:.4f} {\"✓\" if per < best_model_per else \"✗\"}')\n",
     "    if per < best_model_per:\n",
     "        best_model_per = per\n",
     "        best_model = aux_model_file\n",
@@ -444,7 +445,7 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
    ]
   }
  ],

--- a/models.py
+++ b/models.py
@@ -1,9 +1,66 @@
 import math
+from typing import Dict, List
+
 import torch
 from torch import nn
-from torch.nn import TransformerEncoder
 import torch.nn.functional as F
+
 from layers import MFCC, Attention, LinearNorm, ConvNorm, ConvBlock
+
+
+def _stochastic_depth(residual: torch.Tensor, drop_prob: float, training: bool) -> torch.Tensor:
+    """Apply sample-wise stochastic depth to a residual branch."""
+
+    if drop_prob <= 0.0 or not training:
+        return residual
+
+    keep_prob = 1.0 - drop_prob
+    if keep_prob <= 0.0:
+        return torch.zeros_like(residual)
+
+    shape = (residual.size(0),) + (1,) * (residual.dim() - 1)
+    random_tensor = keep_prob + torch.rand(shape, dtype=residual.dtype, device=residual.device)
+    random_tensor.floor_()
+    return residual / keep_prob * random_tensor
+
+
+class EncoderStage(nn.Module):
+    """A convolutional encoder stage with optional stochastic depth."""
+
+    def __init__(self, hidden_dim: int, drop_prob: float = 0.0):
+        super().__init__()
+        self.drop_prob = float(max(0.0, drop_prob))
+        self.block = ConvBlock(hidden_dim)
+        self.post_norm = nn.GroupNorm(num_groups=1, num_channels=hidden_dim)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        residual = self.block(x)
+        residual = self.post_norm(residual)
+
+        if self.drop_prob > 0.0:
+            delta = residual - x
+            delta = _stochastic_depth(delta, self.drop_prob, self.training)
+            residual = x + delta
+
+        return residual
+
+
+class IntermediateCTCHead(nn.Module):
+    """Light-weight projection head for intermediate CTC supervision."""
+
+    def __init__(self, hidden_dim: int, n_token: int, dropout: float = 0.1):
+        super().__init__()
+        projection_dim = max(1, hidden_dim // 2)
+        self.layers = nn.Sequential(
+            ConvNorm(hidden_dim, projection_dim),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            ConvNorm(projection_dim, n_token),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        logits = self.layers(x)
+        return logits.transpose(1, 2)
 
 def build_model(model_params={}, model_type='asr'):
     model = ASRCNN(**model_params)
@@ -19,17 +76,37 @@ class ASRCNN(nn.Module):
                  token_embedding_dim=256,
                  location_kernel_size=63,
                  multi_task_config=None,
+                 stabilization_config=None,
     ):
         super().__init__()
         self.n_token = n_token
         self.n_down = 1
         self.to_mfcc = MFCC()
         self.init_cnn = ConvNorm(input_dim//2, hidden_dim, kernel_size=7, padding=3, stride=2)
-        self.cnns = nn.Sequential(
-            *[nn.Sequential(
-                ConvBlock(hidden_dim),
-                nn.GroupNorm(num_groups=1, num_channels=hidden_dim)
-            ) for n in range(n_layers)])
+        self.stabilization_config = stabilization_config or {}
+        self._stochastic_depth_cfg = self.stabilization_config.get('stochastic_depth', {}) or {}
+        self.enable_stochastic_depth = bool(self._stochastic_depth_cfg.get('enabled', False))
+
+        self.encoder_layers = nn.ModuleList()
+        for layer_idx in range(1, n_layers + 1):
+            if self.enable_stochastic_depth:
+                drop_prob = self._get_stochastic_depth_prob(layer_idx, n_layers)
+            else:
+                drop_prob = 0.0
+            self.encoder_layers.append(EncoderStage(hidden_dim, drop_prob=drop_prob))
+
+        ictc_cfg = self.stabilization_config.get('intermediate_ctc', {}) or {}
+        self.enable_intermediate_ctc = bool(ictc_cfg.get('enabled', False))
+        ictc_dropout = float(ictc_cfg.get('dropout', 0.1))
+        self.intermediate_ctc_layers = self._parse_intermediate_layers(ictc_cfg.get('layers'), n_layers)
+        if self.enable_intermediate_ctc and self.intermediate_ctc_layers:
+            self.intermediate_ctc_heads = nn.ModuleDict({
+                str(layer_idx): IntermediateCTCHead(hidden_dim, n_token, dropout=ictc_dropout)
+                for layer_idx in self.intermediate_ctc_layers
+            })
+        else:
+            self.intermediate_ctc_heads = nn.ModuleDict()
+
         self.projection = ConvNorm(hidden_dim, hidden_dim // 2)
         self.multi_task_config = multi_task_config or {}
         self.use_ctc = bool(self.multi_task_config.get('use_ctc', True))
@@ -93,14 +170,70 @@ class ASRCNN(nn.Module):
             self.pron_error_head = None
             self.pron_error_num_classes = 0
 
+    def _get_stochastic_depth_prob(self, layer_idx: int, total_layers: int) -> float:
+        strategy = str(self._stochastic_depth_cfg.get('mode', 'linear')).lower()
+        min_drop = float(self._stochastic_depth_cfg.get('min_drop_rate', 0.0))
+        max_drop = float(self._stochastic_depth_cfg.get('max_drop_rate', self._stochastic_depth_cfg.get('drop_rate', 0.0)))
+        max_drop = max(0.0, min(1.0, max_drop))
+        min_drop = max(0.0, min(1.0, min_drop))
+        if total_layers <= 1:
+            return max_drop
+
+        if strategy == 'uniform':
+            return max_drop
+
+        progress = (layer_idx - 1) / (total_layers - 1)
+        drop = min_drop + (max_drop - min_drop) * progress
+        return max(0.0, min(1.0, drop))
+
+    @staticmethod
+    def _parse_intermediate_layers(layers_config, max_layers: int) -> List[int]:
+        if layers_config is None:
+            return []
+
+        parsed: List[int] = []
+        if isinstance(layers_config, dict):
+            source = layers_config.keys()
+        else:
+            source = layers_config
+
+        for entry in source:
+            if isinstance(entry, dict):
+                idx = entry.get('index', entry.get('layer'))
+            else:
+                idx = entry
+            try:
+                value = int(idx)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= value <= max_layers:
+                parsed.append(value)
+
+        # Preserve ordering but drop duplicates
+        seen = set()
+        ordered: List[int] = []
+        for value in parsed:
+            if value not in seen:
+                seen.add(value)
+                ordered.append(value)
+        return ordered
+
     def forward(self, x, src_key_padding_mask=None, text_input=None):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
+        intermediate_outputs: Dict[str, torch.Tensor] = {}
+        for layer_idx, layer in enumerate(self.encoder_layers, start=1):
+            x = layer(x)
+            head = self.intermediate_ctc_heads.get(str(layer_idx))
+            if head is not None:
+                intermediate_outputs[str(layer_idx)] = head(x)
 
         x = self.projection(x)
         x = x.transpose(1, 2)
         outputs = {"encoder_features": x}
+
+        if intermediate_outputs:
+            outputs["intermediate_ctc_logits"] = intermediate_outputs
 
         if self.use_ctc and self.ctc_linear is not None:
             ctc_logit = self.ctc_linear(x)
@@ -177,13 +310,33 @@ class ASRCNN(nn.Module):
         else:
             filtered_state = state_dict
 
-        return super().load_state_dict(filtered_state, strict=strict)
+        remapped = filtered_state.__class__()
+        for key, value in filtered_state.items():
+            if key.startswith('cnns.'):
+                segments = key.split('.')
+                if len(segments) >= 3:
+                    layer_idx = segments[1]
+                    stage_idx = segments[2]
+                    remainder = segments[3:]
+                    new_segments = ['encoder_layers', layer_idx]
+                    if stage_idx == '0':
+                        new_segments.append('block')
+                        new_segments.extend(remainder)
+                    elif stage_idx == '1':
+                        new_segments.append('post_norm')
+                        new_segments.extend(remainder)
+                    else:
+                        new_segments.extend(segments[2:])
+                    key = '.'.join(new_segments)
+            remapped[key] = value
+
+        return super().load_state_dict(remapped, strict=strict)
 
     def get_feature(self, x):
         x = self.to_mfcc(x)
         x = self.init_cnn(x)
-        x = self.cnns(x)
-        x = self.instance_norm(x)
+        for layer in self.encoder_layers:
+            x = layer(x)
         x = self.projection(x)
         return x
 

--- a/models.py
+++ b/models.py
@@ -224,9 +224,9 @@ class ASRCNN(nn.Module):
         intermediate_outputs: Dict[str, torch.Tensor] = {}
         for layer_idx, layer in enumerate(self.encoder_layers, start=1):
             x = layer(x)
-            head = self.intermediate_ctc_heads.get(str(layer_idx))
-            if head is not None:
-                intermediate_outputs[str(layer_idx)] = head(x)
+            key = str(layer_idx)
+            if key in self.intermediate_ctc_heads:
+                intermediate_outputs[key] = self.intermediate_ctc_heads[key](x)
 
         x = self.projection(x)
         x = x.transpose(1, 2)

--- a/train.py
+++ b/train.py
@@ -317,8 +317,11 @@ def main(config_path):
         speaker_cfg['num_speakers'] = inferred
         multi_task_config['speaker'] = speaker_cfg
 
+    stabilization_config = cfg_get_nested(config, 'stabilization', {}) or {}
+
     model_params = dict(model_params)
     model_params['multi_task_config'] = multi_task_config
+    model_params['stabilization_config'] = stabilization_config
 
     print("Using model parameters:", model_params)
 
@@ -339,7 +342,7 @@ def main(config_path):
 
     blank_index = sorted_train_dataloader.dataset.text_cleaner.word_index_dictionary[" "] # get blank index
     criterion = build_criterion(critic_params={
-                'ctc': {'blank': blank_index},
+                'ctc': {'blank': blank_index, 'reduction': 'none', 'zero_infinity': True},
         }, entropy_params=entropy_params, multi_task_config=multi_task_config)
 
     if enable_early_stopping:
@@ -359,6 +362,11 @@ def main(config_path):
     frame_weight = float(loss_weight_config.get('frame_phoneme', 0.0)) if frame_cfg.get('enabled', False) else 0.0
     speaker_weight = float(loss_weight_config.get('speaker', 0.0)) if speaker_cfg.get('enabled', False) else 0.0
     pron_weight = float(loss_weight_config.get('pronunciation_error', 0.0)) if pron_cfg.get('enabled', False) else 0.0
+    mixspeech_config = stabilization_config.get('mix_speech', {}) or {}
+    intermediate_ctc_config = stabilization_config.get('intermediate_ctc', {}) or {}
+    if isinstance(intermediate_ctc_config, dict) and 'loss_weight' not in intermediate_ctc_config:
+        intermediate_ctc_config = dict(intermediate_ctc_config)
+        intermediate_ctc_config['loss_weight'] = float(loss_weight_config.get('intermediate_ctc', 0.0))
 
     trainer = Trainer(model=model,
                     criterion=criterion,
@@ -380,7 +388,9 @@ def main(config_path):
                     pron_error_weight=pron_weight,
                     enable_frame_classifier=frame_cfg.get('enabled', False),
                     enable_speaker=speaker_cfg.get('enabled', False),
-                    enable_pronunciation_error=pron_cfg.get('enabled', False)
+                    enable_pronunciation_error=pron_cfg.get('enabled', False),
+                    mixspeech_config=mixspeech_config,
+                    intermediate_ctc_config=intermediate_ctc_config
                     )
 
     pretrained_model = cfg_get_nested( config, 'pretrained_model', '' )

--- a/trainer.py
+++ b/trainer.py
@@ -573,8 +573,13 @@ class Trainer(object):
             s2s_attn = model_outputs.get('s2s_attn')
 
             if self.ctc_weight > 0 and ppgs is not None:
-                loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
-                                              text_input, mel_input_length, text_input_length)
+                loss_ctc = self._compute_ctc_loss(
+                    ppgs,
+                    text_input,
+                    mel_input_length,
+                    text_input_length,
+                    mix_metadata=None,
+                )
                 eval_losses["eval/ctc"].append(loss_ctc.item())
             else:
                 loss_ctc = torch.zeros(1, device=self.device)

--- a/trainer.py
+++ b/trainer.py
@@ -330,6 +330,10 @@ class Trainer(object):
         if primary_loss.dim() == 0:
             primary_loss = primary_loss.unsqueeze(0)
 
+        target_lengths = target_lengths.to(primary_loss.device)
+        normalizer = target_lengths.to(primary_loss.dtype).clamp_min(1)
+        primary_loss = primary_loss / normalizer
+
         total_loss = primary_loss
         if mix_metadata and mix_metadata.get('lam_secondary') is not None:
             lam_primary = mix_metadata['lam_primary'].to(primary_loss.dtype)
@@ -343,6 +347,9 @@ class Trainer(object):
                 secondary_loss = ctc(log_probs, secondary_targets, input_lengths, secondary_lengths)
                 if secondary_loss.dim() == 0:
                     secondary_loss = secondary_loss.unsqueeze(0)
+                secondary_lengths = secondary_lengths.to(primary_loss.device)
+                secondary_norm = secondary_lengths.to(primary_loss.dtype).clamp_min(1)
+                secondary_loss = secondary_loss / secondary_norm
             else:
                 secondary_loss = torch.zeros_like(primary_loss)
 

--- a/trainer.py
+++ b/trainer.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from utils import calc_wer
 
 import logging
+from torch.distributions import Beta
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -45,7 +46,9 @@ class Trainer(object):
                  pron_error_weight=0.0,
                  enable_frame_classifier=False,
                  enable_speaker=False,
-                 enable_pronunciation_error=False):
+                 enable_pronunciation_error=False,
+                 mixspeech_config=None,
+                 intermediate_ctc_config=None):
 
         self.steps = initial_steps
         self.epochs = initial_epochs
@@ -76,6 +79,45 @@ class Trainer(object):
         self.enable_frame_classifier = enable_frame_classifier
         self.enable_speaker = enable_speaker
         self.enable_pronunciation_error = enable_pronunciation_error
+
+        self.mixspeech_config = mixspeech_config or {}
+        self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
+        self.mixspeech_prob = float(self.mixspeech_config.get('prob', 0.5))
+        self.mixspeech_alpha = float(self.mixspeech_config.get('alpha', 0.3))
+        self.mixspeech_dominant = bool(self.mixspeech_config.get('dominant_mix', True))
+
+        ictc_cfg = intermediate_ctc_config or {}
+        self.intermediate_ctc_enabled = bool(ictc_cfg.get('enabled', False))
+        self.intermediate_ctc_weight = float(ictc_cfg.get('loss_weight', 0.0))
+        self.intermediate_ctc_layer_weights = self._parse_intermediate_layer_weights(ictc_cfg.get('layers'))
+
+    @staticmethod
+    def _parse_intermediate_layer_weights(layers_config):
+        weights = {}
+        if layers_config is None:
+            return weights
+
+        if isinstance(layers_config, dict):
+            iterator = layers_config.items()
+        else:
+            iterator = []
+            for entry in layers_config:
+                if isinstance(entry, dict):
+                    idx = entry.get('index', entry.get('layer'))
+                    weight = entry.get('weight', entry.get('loss_weight', 1.0))
+                else:
+                    idx = entry
+                    weight = 1.0
+                iterator.append((idx, weight))
+
+        for idx, weight in iterator:
+            try:
+                layer_idx = int(idx)
+                weights[str(layer_idx)] = float(weight)
+            except (TypeError, ValueError):
+                continue
+
+        return weights
 
     def save_checkpoint(self, checkpoint_path):
         """Save checkpoint.
@@ -234,6 +276,80 @@ class Trainer(object):
 
         return palette
 
+    def _apply_mixspeech(self, mel_input):
+        if not self.mixspeech_enabled or mel_input.size(0) < 2 or self.mixspeech_prob <= 0.0:
+            return mel_input, None
+
+        device = mel_input.device
+        batch_size = mel_input.size(0)
+        mix_mask = torch.rand(batch_size, device=device) < self.mixspeech_prob
+        if not mix_mask.any():
+            return mel_input, None
+
+        perm = torch.randperm(batch_size, device=device)
+        if self.mixspeech_alpha > 0.0:
+            beta = Beta(self.mixspeech_alpha, self.mixspeech_alpha)
+            lam = beta.sample((batch_size,)).to(device=device, dtype=mel_input.dtype)
+        else:
+            lam = torch.full((batch_size,), 0.5, device=device, dtype=mel_input.dtype)
+
+        mixed = mel_input.clone()
+        lam_primary = torch.ones(batch_size, device=device, dtype=mel_input.dtype)
+        lam_secondary = torch.zeros(batch_size, device=device, dtype=mel_input.dtype)
+        secondary_indices = torch.full((batch_size,), -1, device=device, dtype=torch.long)
+        applied = False
+
+        for idx in range(batch_size):
+            if not mix_mask[idx] or perm[idx].item() == idx:
+                continue
+            partner = int(perm[idx].item())
+            lam_val = lam[idx]
+            if self.mixspeech_dominant:
+                lam_val = torch.max(lam_val, 1.0 - lam_val)
+            mixed[idx] = lam_val * mel_input[idx] + (1.0 - lam_val) * mel_input[partner]
+            lam_primary[idx] = lam_val
+            lam_secondary[idx] = 1.0 - lam_val
+            secondary_indices[idx] = partner
+            applied = True
+
+        if not applied:
+            return mel_input, None
+
+        metadata = {
+            'lam_primary': lam_primary,
+            'lam_secondary': lam_secondary,
+            'secondary_indices': secondary_indices,
+            'avg_lambda': float(lam_primary.mean().item()),
+        }
+        return mixed, metadata
+
+    def _compute_ctc_loss(self, logits, targets, input_lengths, target_lengths, mix_metadata=None):
+        ctc = self.criterion['ctc']
+        log_probs = logits.log_softmax(dim=2).transpose(0, 1)
+        primary_loss = ctc(log_probs, targets, input_lengths, target_lengths)
+        if primary_loss.dim() == 0:
+            primary_loss = primary_loss.unsqueeze(0)
+
+        total_loss = primary_loss
+        if mix_metadata and mix_metadata.get('lam_secondary') is not None:
+            lam_primary = mix_metadata['lam_primary'].to(primary_loss.dtype)
+            lam_secondary = mix_metadata['lam_secondary'].to(primary_loss.dtype)
+            secondary_indices = mix_metadata['secondary_indices']
+            if torch.any(lam_secondary > 0):
+                fallback = torch.arange(targets.size(0), device=targets.device, dtype=torch.long)
+                secondary_indices = torch.where(secondary_indices >= 0, secondary_indices, fallback)
+                secondary_targets = targets.index_select(0, secondary_indices)
+                secondary_lengths = target_lengths.index_select(0, secondary_indices)
+                secondary_loss = ctc(log_probs, secondary_targets, input_lengths, secondary_lengths)
+                if secondary_loss.dim() == 0:
+                    secondary_loss = secondary_loss.unsqueeze(0)
+            else:
+                secondary_loss = torch.zeros_like(primary_loss)
+
+            total_loss = primary_loss * lam_primary + secondary_loss * lam_secondary
+
+        return total_loss.mean()
+
     def run(self, batch):
         # FIX: trying to fix OOM errors
         #torch.cuda.empty_cache()
@@ -252,6 +368,11 @@ class Trainer(object):
         else:
             speaker_ids = torch.zeros(text_input.size(0), device=self.device, dtype=torch.long)
         speaker_ids = speaker_ids.long()
+
+        mix_metadata = None
+        if self.mixspeech_enabled and self.model.training:
+            mel_input, mix_metadata = self._apply_mixspeech(mel_input)
+
         mel_input_length = mel_input_length // (2 ** self.model.n_down)
         future_mask = self.model.get_future_mask(
             mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
@@ -261,12 +382,15 @@ class Trainer(object):
             mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
         losses = {}
+        if mix_metadata:
+            losses['mixspeech/avg_lambda'] = mix_metadata['avg_lambda']
+            active_ratio = (mix_metadata['secondary_indices'] >= 0).float().mean().item()
+            losses['mixspeech/applicable_ratio'] = active_ratio
         total_loss = torch.zeros(1, device=self.device)
 
         ppgs = model_outputs.get('ctc_logits')
         if self.ctc_weight > 0 and ppgs is not None:
-            loss_ctc = self.criterion['ctc'](ppgs.log_softmax(dim=2).transpose(0, 1),
-                                          text_input, mel_input_length, text_input_length)
+            loss_ctc = self._compute_ctc_loss(ppgs, text_input, mel_input_length, text_input_length, mix_metadata)
             total_loss = total_loss + self.ctc_weight * loss_ctc
             losses['ctc'] = loss_ctc.item()
         else:
@@ -275,14 +399,58 @@ class Trainer(object):
         s2s_pred = model_outputs.get('s2s_logits')
         s2s_attn = model_outputs.get('s2s_attn')
         if self.s2s_weight > 0 and s2s_pred is not None:
-            loss_s2s = 0
-            for _s2s_pred, _text_input, _text_length in zip(s2s_pred, text_input, text_input_length):
-                loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
-            loss_s2s /= max(1, text_input.size(0))
+            loss_s2s = torch.zeros(1, device=self.device)
+            total_samples = text_input.size(0)
+            lam_primary = mix_metadata['lam_primary'] if mix_metadata else None
+            lam_secondary = mix_metadata['lam_secondary'] if mix_metadata else None
+            secondary_indices = mix_metadata['secondary_indices'] if mix_metadata else None
+            fallback_indices = torch.arange(total_samples, device=self.device, dtype=torch.long)
+
+            for idx, (_s2s_pred, _text_input, _text_length) in enumerate(zip(s2s_pred, text_input, text_input_length)):
+                main_len = int(_text_length.item())
+                main_len = min(main_len, _s2s_pred.size(0))
+                if main_len <= 0:
+                    continue
+                ce_loss = self.criterion['ce'](_s2s_pred[:main_len], _text_input[:main_len])
+                weight_primary = lam_primary[idx] if lam_primary is not None else 1.0
+                sample_loss = ce_loss * weight_primary
+
+                if lam_secondary is not None and lam_secondary[idx] > 0:
+                    partner_idx = secondary_indices[idx] if secondary_indices[idx] >= 0 else fallback_indices[idx]
+                    partner_idx = int(partner_idx.item())
+                    partner_len = int(text_input_length[partner_idx].item())
+                    partner_len = min(partner_len, _s2s_pred.size(0))
+                    if partner_len > 0:
+                        partner_target = text_input[partner_idx, :partner_len]
+                        ce_partner = self.criterion['ce'](_s2s_pred[:partner_len], partner_target)
+                        sample_loss = sample_loss + ce_partner * lam_secondary[idx]
+
+                loss_s2s = loss_s2s + sample_loss
+
+            loss_s2s = loss_s2s / max(1, text_input.size(0))
             total_loss = total_loss + self.s2s_weight * loss_s2s
             losses['s2s'] = loss_s2s.item()
         else:
             loss_s2s = torch.zeros(1, device=self.device)
+
+        intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
+        if (
+            self.intermediate_ctc_enabled
+            and self.intermediate_ctc_weight > 0.0
+            and isinstance(intermediate_outputs, dict)
+            and intermediate_outputs
+        ):
+            layer_losses = torch.zeros(1, device=self.device)
+            for layer_key, logits in intermediate_outputs.items():
+                if not isinstance(logits, torch.Tensor):
+                    continue
+                layer_loss = self._compute_ctc_loss(logits, text_input, mel_input_length, text_input_length, mix_metadata)
+                weight = float(self.intermediate_ctc_layer_weights.get(str(layer_key), 1.0))
+                layer_losses = layer_losses + weight * layer_loss
+                losses[f'intermediate_ctc/layer_{layer_key}'] = layer_loss.item()
+
+            total_loss = total_loss + self.intermediate_ctc_weight * layer_losses
+            losses['intermediate_ctc'] = layer_losses.item()
 
         if self.enable_frame_classifier and self.frame_weight > 0:
             frame_logits = model_outputs.get('frame_phoneme_logits')

--- a/utils.py
+++ b/utils.py
@@ -80,9 +80,12 @@ def drop_duplicated(chars):
 def build_criterion(critic_params={}, entropy_params={}, multi_task_config=None):
     multi_task_config = multi_task_config or {}
 
+    ctc_params = dict(critic_params.get('ctc', {}))
+    ctc_params.setdefault('reduction', 'none')
+
     criterion = {
         "ce": nn.CrossEntropyLoss(ignore_index=-1, **entropy_params),
-        "ctc": torch.nn.CTCLoss(**critic_params.get('ctc', {})),
+        "ctc": torch.nn.CTCLoss(**ctc_params),
     }
 
     frame_cfg = multi_task_config.get('frame_phoneme', {}) or {}


### PR DESCRIPTION
## Summary
- add optional stochastic depth blocks and intermediate CTC heads to the encoder with config wiring
- integrate MixSpeech data augmentation and intermediate CTC loss handling in the trainer and training script
- expose stabilization toggles in the default config and utility notebooks so the new features can be exercised interactively

## Testing
- python -m compileall models.py trainer.py train.py utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d567bac2f48332acd0dc6a00f96518