### PR TITLE
Add configurable MWER training support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -40,6 +40,15 @@ multi_task:
     enabled: false
     num_classes: 2  # set to the number of pronunciation error categories your dataset annotates
 
+sequence_objectives:
+  mwer:
+    enabled: false
+    num_samples: 4
+    ignore_indexes:
+      - 0
+      - -1
+    length_normalize: false
+
 stabilization:
   stochastic_depth:
     enabled: false
@@ -125,6 +134,7 @@ loss_weights:
   intermediate_ctc: 0.0
   # Weight applied to the auxiliary loss from the self-conditioned CTC predictor.
   self_conditioned_ctc: 0.0
+  mwer: 0.0
 
 decoding:
   beam_search:

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -205,7 +205,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -251,7 +270,17 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')"
+    "print(f'Blank token id: {BLANK_ID}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -204,7 +204,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -242,7 +261,17 @@
     "if \" \" not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = int(token_map[\" \"])\n",
-    "print(f\"Blank token id: {BLANK_ID}\")\n"
+    "print(f\"Blank token id: {BLANK_ID}\")\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -214,7 +214,27 @@
     "        device='cuda' if device.type == 'cuda' else 'cpu',\n",
     "        dataset_config=dataset_cfg,\n",
     "    )\n",
-    "    return loader, path_list\n"
+    "    return loader, path_list\n",
+    "\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -251,7 +271,17 @@
     "\n",
     "dev_loader, val_entries = build_dev_dataloader_from_config(config, device)\n",
     "print(f'Validation dataset size: {len(val_entries)} samples')\n",
-    "print(f'Batch size --> {dev_loader.batch_size}')\n"
+    "print(f'Batch size --> {dev_loader.batch_size}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -203,7 +203,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -249,7 +268,17 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')\n"
+    "print(f'Blank token id: {BLANK_ID}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -198,7 +198,26 @@
     "    return loader\n",
     "\n",
     "NORMALIZATION_MEAN = -4.0\n",
-    "NORMALIZATION_STD = 4.0"
+    "NORMALIZATION_STD = 4.0\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -252,7 +271,17 @@
     "    if decoder.cold_fusion_lm is not None:\n",
     "        fusion_flags.append('cold fusion LM')\n",
     "    fusion_desc = ' with ' + ' and '.join(fusion_flags) if fusion_flags else ''\n",
-    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n"
+    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -201,7 +201,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -261,7 +280,17 @@
     "    if decoder.cold_fusion_lm is not None:\n",
     "        fusion_flags.append('cold fusion LM')\n",
     "    fusion_desc = ' with ' + ' and '.join(fusion_flags) if fusion_flags else ''\n",
-    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n"
+    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -188,7 +188,26 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -227,7 +246,17 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')"
+    "print(f'Blank token id: {BLANK_ID}')\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives. Additionally, Minimum Word Error Rate (MWER) sequence training can be toggled via the `sequence_objectives.mwer` section and weighted with `loss_weights.mwer` to complement the joint CTC + attention objectives."
    ]
   },
   {
@@ -146,7 +146,25 @@
     "    asr_model = _load_model(model_params, ASR_MODEL_PATH)\n",
     "\n",
     "    return asr_model\n",
-    "\n"
+    "\n",
+    "def describe_sequence_objectives(config):\n",
+    "    seq_cfg = cfg_get_nested(config, 'sequence_objectives', {}) or {}\n",
+    "    mwer_cfg = seq_cfg.get('mwer', {}) or {}\n",
+    "    enabled = bool(mwer_cfg.get('enabled', False))\n",
+    "    ignore = mwer_cfg.get('ignore_indexes', [0, -1])\n",
+    "    if isinstance(ignore, (int, float, str)):\n",
+    "        ignore = [ignore]\n",
+    "    try:\n",
+    "        num_samples = int(mwer_cfg.get('num_samples', 0) or 0)\n",
+    "    except (TypeError, ValueError):\n",
+    "        num_samples = 0\n",
+    "    summary = {\n",
+    "        'enabled': enabled,\n",
+    "        'num_samples': num_samples,\n",
+    "        'ignore_indexes': list(ignore),\n",
+    "        'length_normalize': bool(mwer_cfg.get('length_normalize', False)),\n",
+    "    }\n",
+    "    return summary\n"
    ]
   },
   {
@@ -186,7 +204,17 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK ✓\")\n"
+    "print( \"All OK ✓\")\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {
@@ -445,7 +473,17 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n",
+    "\n",
+    "\n",
+    "sequence_summary = describe_sequence_objectives(config)\n",
+    "print(f\"MWER enabled: {sequence_summary['enabled']}\")\n",
+    "if sequence_summary['enabled']:\n",
+    "    print(f\"MWER samples: {sequence_summary['num_samples']}\")\n",
+    "    print(f\"MWER ignore indexes: {sequence_summary['ignore_indexes']}\")\n",
+    "    print(f\"MWER length normalize: {sequence_summary['length_normalize']}\")\n",
+    "else:\n",
+    "    print(\"MWER is disabled in this configuration.\")\n"
    ]
   },
   {

--- a/train.py
+++ b/train.py
@@ -351,6 +351,8 @@ def main(config_path):
         early_stopping = None
 
     loss_weight_config = cfg_get_nested(config, 'loss_weights', {}) or {}
+    sequence_objectives = cfg_get_nested(config, 'sequence_objectives', {}) or {}
+    mwer_config = sequence_objectives.get('mwer', {}) or {}
     use_ctc = bool(multi_task_config.get('use_ctc', True))
     use_s2s = bool(multi_task_config.get('use_seq2seq', True))
     frame_cfg = multi_task_config.get('frame_phoneme', {}) or {}
@@ -362,6 +364,7 @@ def main(config_path):
     frame_weight = float(loss_weight_config.get('frame_phoneme', 0.0)) if frame_cfg.get('enabled', False) else 0.0
     speaker_weight = float(loss_weight_config.get('speaker', 0.0)) if speaker_cfg.get('enabled', False) else 0.0
     pron_weight = float(loss_weight_config.get('pronunciation_error', 0.0)) if pron_cfg.get('enabled', False) else 0.0
+    mwer_weight = float(loss_weight_config.get('mwer', 0.0)) if mwer_config.get('enabled', False) else 0.0
     mixspeech_config = stabilization_config.get('mix_speech', {}) or {}
     intermediate_ctc_config = stabilization_config.get('intermediate_ctc', {}) or {}
     if isinstance(intermediate_ctc_config, dict) and 'loss_weight' not in intermediate_ctc_config:
@@ -399,6 +402,8 @@ def main(config_path):
                     mixspeech_config=mixspeech_config,
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
+                    mwer_config=mwer_config,
+                    mwer_weight=mwer_weight,
                     steps_per_epoch=steps_per_epoch
                     )
 

--- a/trainer.py
+++ b/trainer.py
@@ -15,7 +15,7 @@ from tqdm import tqdm
 from utils import calc_wer
 
 import logging
-from torch.distributions import Beta
+from torch.distributions import Beta, Categorical
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
@@ -50,6 +50,8 @@ class Trainer(object):
                  mixspeech_config=None,
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
+                 mwer_config=None,
+                 mwer_weight=0.0,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -82,6 +84,16 @@ class Trainer(object):
         self.enable_frame_classifier = enable_frame_classifier
         self.enable_speaker = enable_speaker
         self.enable_pronunciation_error = enable_pronunciation_error
+
+        self.mwer_config = mwer_config or {}
+        self.mwer_enabled = bool(self.mwer_config.get('enabled', False))
+        self.mwer_weight = float(mwer_weight) if self.mwer_enabled else 0.0
+        self.mwer_num_samples = int(self.mwer_config.get('num_samples', 4))
+        self.mwer_length_normalize = bool(self.mwer_config.get('length_normalize', False))
+        ignore_indexes = self.mwer_config.get('ignore_indexes', [0, -1])
+        if isinstance(ignore_indexes, (int, float, str)):
+            ignore_indexes = [ignore_indexes]
+        self.mwer_ignore_indexes = list(ignore_indexes)
 
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
@@ -476,6 +488,69 @@ class Trainer(object):
 
         return total_loss.mean()
 
+    def _compute_mwer_loss(self, logits, targets, target_lengths):
+        if logits is None:
+            return torch.zeros(1, device=self.device), {}
+
+        if self.mwer_num_samples <= 0:
+            return torch.zeros(1, device=self.device), {}
+
+        log_probs = torch.log_softmax(logits, dim=-1)
+        batch_size = log_probs.size(0)
+
+        total_loss = logits.new_zeros(())
+        total_wer = 0.0
+        valid_sequences = 0
+
+        for batch_idx in range(batch_size):
+            target_len = int(target_lengths[batch_idx].item())
+            if target_len <= 0:
+                continue
+
+            step_log_probs = log_probs[batch_idx, :target_len]
+            if step_log_probs.numel() == 0:
+                continue
+
+            dist = Categorical(logits=step_log_probs)
+            samples = dist.sample((self.mwer_num_samples,))
+
+            expanded = step_log_probs.unsqueeze(0).expand(self.mwer_num_samples, -1, -1)
+            token_log_probs = torch.gather(expanded, 2, samples.unsqueeze(-1)).squeeze(-1)
+            seq_log_probs = token_log_probs.sum(dim=1)
+            if self.mwer_length_normalize:
+                seq_log_probs = seq_log_probs / max(1, target_len)
+
+            target_seq = targets[batch_idx, :target_len].detach().cpu()
+            wers = []
+            for sample in samples:
+                wers.append(
+                    calc_wer(
+                        target_seq,
+                        sample.detach().cpu(),
+                        ignore_indexes=self.mwer_ignore_indexes,
+                    )
+                )
+
+            wers_tensor = step_log_probs.new_tensor(wers)
+            baseline = wers_tensor.mean()
+            advantages = wers_tensor - baseline
+
+            # Detach the reward term to avoid gradients flowing through the WER estimate
+            total_loss = total_loss + torch.sum(advantages.detach() * seq_log_probs) / max(1, self.mwer_num_samples)
+            total_wer += float(baseline.item())
+            valid_sequences += 1
+
+        if valid_sequences == 0:
+            return logits.new_zeros(()), {}
+
+        total_loss = total_loss / max(1, valid_sequences)
+        average_wer = total_wer / max(1, valid_sequences)
+
+        if torch.isnan(total_loss):
+            total_loss = logits.new_zeros(())
+
+        return total_loss, {"sample_mean_wer": average_wer, "num_samples": float(self.mwer_num_samples)}
+
     def run(self, batch):
         # FIX: trying to fix OOM errors
         #torch.cuda.empty_cache()
@@ -558,6 +633,22 @@ class Trainer(object):
             losses['s2s'] = loss_s2s.item()
         else:
             loss_s2s = torch.zeros(1, device=self.device)
+
+        if (
+            self.mwer_enabled
+            and self.mwer_weight > 0.0
+            and isinstance(s2s_pred, torch.Tensor)
+            and self.mwer_num_samples > 0
+        ):
+            loss_mwer, stats_mwer = self._compute_mwer_loss(
+                s2s_pred,
+                text_input,
+                text_input_length,
+            )
+            total_loss = total_loss + self.mwer_weight * loss_mwer
+            losses['mwer'] = loss_mwer.item()
+            for key, value in stats_mwer.items():
+                losses[f'mwer/{key}'] = float(value)
 
         intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
         if (

--- a/utils.py
+++ b/utils.py
@@ -74,6 +74,9 @@ def calc_wer(target, pred, ignore_indexes=[0]):
     return error
 
 def drop_duplicated(chars):
+    if not chars:
+        return []
+
     ret_chars = [chars[0]]
     for prev, curr in zip(chars[:-1], chars[1:]):
         if prev != curr:


### PR DESCRIPTION
## Summary
- add a configurable `sequence_objectives.mwer` block and corresponding weight to the training pipeline
- implement a sampling-based MWER loss in the trainer while keeping joint CTC + attention flows intact
- surface the MWER configuration helper and status output across the utility notebooks

## Testing
- python -m compileall trainer.py train.py utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d697e3b9848332acb7489ed1d8e785