### PR TITLE
Add configurable entropy regularization support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -126,6 +126,24 @@ loss_weights:
   # Weight applied to the auxiliary loss from the self-conditioned CTC predictor.
   self_conditioned_ctc: 0.0
 
+regularization:
+  entropy:
+    enabled: false
+    # Choose whether to minimise (sharpen) or maximise (smooth) the model's output distributions.
+    mode: minimize  # options: minimize, maximize
+    # Numerical stability constant added inside the log operation.
+    eps: 1.0e-6
+    targets:
+      # Entropy penalties can be enabled independently for each prediction head.
+      ctc:
+        enabled: true
+        weight: 0.0
+        length_normalize: true
+      s2s:
+        enabled: true
+        weight: 0.0
+        length_normalize: true
+
 decoding:
   beam_search:
     enabled: true

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -346,7 +348,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -345,7 +347,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -396,7 +398,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -370,7 +372,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -517,7 +519,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -464,7 +466,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -352,7 +354,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -6,7 +6,9 @@
    "metadata": {},
    "source": [
     "## Multi-task auxiliary objectives update\n",
-    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives."
+    "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
+    "\n",
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
    ]
   },
   {
@@ -470,7 +472,24 @@
     "  self_conditioned_ctc: 0.2\n",
     "```\n",
     "\n",
-    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals."
+    "With the feature enabled the trainer will expose `self_conditioned_ctc_logits` and `self_conditioned_ctc_log_probs` in the model outputs so they can be visualised or scored inside the notebook just like the existing CTC signals.\n",
+    "\n",
+    "```yaml\n",
+    "regularization:\n",
+    "  entropy:\n",
+    "    enabled: false\n",
+    "    mode: minimize  # set to \"maximize\" to encourage smoother distributions\n",
+    "    eps: 1.0e-6\n",
+    "    targets:\n",
+    "      ctc:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "      s2s:\n",
+    "        enabled: true\n",
+    "        weight: 0.0\n",
+    "        length_normalize: true\n",
+    "```"
    ]
   }
  ],

--- a/train.py
+++ b/train.py
@@ -351,6 +351,8 @@ def main(config_path):
         early_stopping = None
 
     loss_weight_config = cfg_get_nested(config, 'loss_weights', {}) or {}
+    regularization_config = cfg_get_nested(config, 'regularization', {}) or {}
+    entropy_regularization_config = cfg_get_nested(regularization_config, 'entropy', {}) or {}
     use_ctc = bool(multi_task_config.get('use_ctc', True))
     use_s2s = bool(multi_task_config.get('use_seq2seq', True))
     frame_cfg = multi_task_config.get('frame_phoneme', {}) or {}
@@ -399,6 +401,7 @@ def main(config_path):
                     mixspeech_config=mixspeech_config,
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
+                    entropy_regularization_config=entropy_regularization_config,
                     steps_per_epoch=steps_per_epoch
                     )
 

--- a/trainer.py
+++ b/trainer.py
@@ -50,6 +50,7 @@ class Trainer(object):
                  mixspeech_config=None,
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
+                 entropy_regularization_config=None,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -99,6 +100,16 @@ class Trainer(object):
         self.self_conditioned_ctc_weight = float(sctc_cfg.get('loss_weight', 0.0))
         self.self_conditioned_ctc_layer_weights = self._parse_intermediate_layer_weights(sctc_cfg.get('layers'))
 
+        entropy_cfg = entropy_regularization_config or {}
+        self.entropy_regularization_enabled = bool(entropy_cfg.get('enabled', False))
+        mode = str(entropy_cfg.get('mode', 'minimize')).lower()
+        if mode not in ('minimize', 'maximize'):
+            mode = 'minimize'
+        self.entropy_regularization_mode = mode
+        self.entropy_regularization_eps = float(entropy_cfg.get('eps', 1.0e-6))
+        targets_cfg = entropy_cfg.get('targets', {}) if isinstance(entropy_cfg, dict) else {}
+        self.entropy_regularization_targets = self._parse_entropy_regularization_targets(targets_cfg, entropy_cfg)
+
         self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
         self._sortagrad_active = bool(
@@ -141,6 +152,103 @@ class Trainer(object):
                 continue
 
         return weights
+
+    @staticmethod
+    def _parse_entropy_regularization_targets(targets_config, root_config):
+        supported = ('ctc', 's2s')
+        parsed = {}
+        for key in supported:
+            cfg = {}
+            if isinstance(targets_config, dict):
+                raw = targets_config.get(key, {})
+            else:
+                raw = {}
+            if isinstance(raw, bool):
+                cfg['enabled'] = raw
+            elif isinstance(raw, (int, float)):
+                cfg['weight'] = float(raw)
+            elif isinstance(raw, dict):
+                cfg.update(raw)
+            weight = float(cfg.get('weight', root_config.get(f'{key}_weight', 0.0) if isinstance(root_config, dict) else 0.0))
+            enabled = cfg.get('enabled', None)
+            if enabled is None:
+                enabled = bool(weight)
+            parsed[key] = {
+                'enabled': bool(enabled),
+                'weight': weight,
+                'length_normalize': bool(cfg.get('length_normalize', True)),
+                'reduction': str(cfg.get('reduction', 'mean')).lower(),
+            }
+        return parsed
+
+    def _entropy_target_config(self, key):
+        if not self.entropy_regularization_enabled:
+            return None
+        cfg = self.entropy_regularization_targets.get(key, {})
+        if not cfg.get('enabled', False):
+            return None
+        weight = float(cfg.get('weight', 0.0))
+        if weight == 0.0:
+            return None
+        return cfg
+
+    def _compute_entropy_regularization(self, logits, lengths=None, key='ctc'):
+        cfg = self._entropy_target_config(key)
+        if cfg is None:
+            return None
+
+        logits = logits.float()
+        probs = torch.softmax(logits, dim=-1)
+        eps = max(self.entropy_regularization_eps, 0.0)
+        if eps > 0.0:
+            probs = probs.clamp_min(eps)
+            probs = probs / probs.sum(dim=-1, keepdim=True)
+        log_probs = torch.log(probs)
+        entropy = -(probs * log_probs).sum(dim=-1)
+
+        if lengths is not None:
+            if lengths.dim() == 1:
+                max_steps = entropy.size(1)
+                mask = torch.arange(max_steps, device=entropy.device).unsqueeze(0)
+                mask = mask < lengths.unsqueeze(1)
+            else:
+                mask = lengths
+                if mask.dim() < entropy.dim():
+                    mask = mask.unsqueeze(-1)
+            mask = mask.to(entropy.dtype)
+            entropy = entropy * mask
+            if cfg.get('length_normalize', True):
+                reduce_dims = tuple(range(1, entropy.dim()))
+                denom = mask.sum(dim=reduce_dims)
+                denom = denom.clamp_min(1.0)
+                entropy = entropy.sum(dim=reduce_dims) / denom
+            else:
+                entropy = entropy.sum(dim=tuple(range(1, entropy.dim())))
+        else:
+            entropy = entropy.mean(dim=tuple(range(1, entropy.dim())))
+
+        reduction = cfg.get('reduction', 'mean')
+        if reduction == 'sum':
+            entropy_value = entropy.sum()
+        elif reduction == 'none':
+            entropy_value = entropy
+        else:
+            entropy_value = entropy.mean()
+
+        if self.entropy_regularization_mode == 'maximize':
+            entropy_value = -entropy_value
+
+        if isinstance(entropy_value, torch.Tensor) and entropy_value.dim() > 0:
+            entropy_value = entropy_value.mean()
+
+        reg_weight = float(cfg.get('weight', 0.0))
+        reg_loss = entropy_value * reg_weight
+        if not torch.is_tensor(reg_loss):
+            reg_loss = torch.tensor(reg_loss, device=logits.device, dtype=logits.dtype)
+        else:
+            reg_loss = reg_loss.to(device=logits.device, dtype=logits.dtype)
+
+        return reg_loss
 
     def _switch_to_shuffled(self, reason=None):
         if self.shuffled_train_dataloader is None:
@@ -559,6 +667,18 @@ class Trainer(object):
         else:
             loss_s2s = torch.zeros(1, device=self.device)
 
+        if self.entropy_regularization_enabled:
+            if ppgs is not None:
+                entropy_ctc = self._compute_entropy_regularization(ppgs, lengths=mel_input_length, key='ctc')
+                if entropy_ctc is not None:
+                    total_loss = total_loss + entropy_ctc
+                    losses['entropy/ctc'] = entropy_ctc.item() if torch.is_tensor(entropy_ctc) else float(entropy_ctc)
+            if s2s_pred is not None:
+                entropy_s2s = self._compute_entropy_regularization(s2s_pred, lengths=text_input_length, key='s2s')
+                if entropy_s2s is not None:
+                    total_loss = total_loss + entropy_s2s
+                    losses['entropy/s2s'] = entropy_s2s.item() if torch.is_tensor(entropy_s2s) else float(entropy_s2s)
+
         intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
         if (
             self.intermediate_ctc_enabled
@@ -747,6 +867,18 @@ class Trainer(object):
                 total_eval_loss = total_eval_loss + self.ctc_weight * loss_ctc
             if self.s2s_weight > 0:
                 total_eval_loss = total_eval_loss + self.s2s_weight * loss_s2s
+
+            if self.entropy_regularization_enabled:
+                if ppgs is not None:
+                    entropy_ctc = self._compute_entropy_regularization(ppgs, lengths=mel_input_length, key='ctc')
+                    if entropy_ctc is not None:
+                        total_eval_loss = total_eval_loss + entropy_ctc
+                        eval_losses['eval/entropy_ctc'].append(entropy_ctc.item())
+                if s2s_pred is not None:
+                    entropy_s2s = self._compute_entropy_regularization(s2s_pred, lengths=text_input_length, key='s2s')
+                    if entropy_s2s is not None:
+                        total_eval_loss = total_eval_loss + entropy_s2s
+                        eval_losses['eval/entropy_s2s'].append(entropy_s2s.item())
 
             intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
             if (


### PR DESCRIPTION
## Summary
- add a configurable entropy regularization section to Configs/config.yml and plumb the settings through train.py
- extend Trainer to compute optional entropy penalties for the CTC and seq2seq heads while keeping existing multi-task losses intact
- update the Utils notebooks to document how to toggle the new entropy regularization features

## Testing
- python -m compileall trainer.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d6ab95750c8332944c478e0c63c539