### PR TITLE
Add configurable ensemble distillation support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -126,6 +126,25 @@ loss_weights:
   # Weight applied to the auxiliary loss from the self-conditioned CTC predictor.
   self_conditioned_ctc: 0.0
 
+distillation:
+  enabled: false
+  temperature: 1.0
+  loss_weight: 1.0
+  strict_loading: false
+  missing_strategy: skip  # options: skip, warn, error
+  targets:
+    ctc:
+      enabled: true
+      weight: 1.0
+    s2s:
+      enabled: true
+      weight: 1.0
+    attention:
+      enabled: false
+      weight: 1.0
+      loss: kl  # options: kl, mse
+  teachers: []  # Populate with teacher definitions containing storage path and key mappings.
+
 regularization:
   entropy:
     enabled: false

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f6a411ce",
    "metadata": {},
    "source": [
@@ -264,7 +286,7 @@
     "## CTC entropy statistics\n",
     "- mean_maxprob often ends up > 0.6;\n",
     "- mean_entropy should drop well below log(V);\n",
-    "- mean_blank_rate typically sits around 0.6–0.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
+    "- mean_blank_rate typically sits around 0.6\u20130.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0993ecfa",
    "metadata": {},
    "source": [
@@ -253,7 +275,7 @@
    "metadata": {},
    "source": [
     "## Mean CTC loss evaluation\n",
-    "- simple early-stopping signal; shouldn’t diverge vs train."
+    "- simple early-stopping signal; shouldn\u2019t diverge vs train."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "225c5b82",
    "metadata": {},
    "source": [
@@ -351,7 +373,7 @@
    "metadata": {},
    "source": [
     "### Diagonal Attention Score\n",
-    "- scores > 0.6–0.7 are usually good; trending higher across training is a healthy sign."
+    "- scores > 0.6\u20130.7 are usually good; trending higher across training is a healthy sign."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "intro-duration",
    "metadata": {},
    "source": [
@@ -260,8 +282,8 @@
    "metadata": {},
    "source": [
     "## Duration statistics computation\n",
-    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz ≈ 12.5 ms/frame → 8–15 frames/phone is typical for EN; tonal languages can vary).\n",
-    "- extremely short (1–2 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
+    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz \u2248 12.5 ms/frame \u2192 8\u201315 frames/phone is typical for EN; tonal languages can vary).\n",
+    "- extremely short (1\u20132 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b57e77d8",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -13,6 +13,28 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f245669c",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -12,6 +12,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0b812a58",

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -12,6 +12,28 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ensemble distillation support\n",
+    "You can now optionally enable ensemble-based knowledge distillation by editing `distillation` in `Configs/config.yml`. Set `enabled: true` and list one or more teachers under `distillation.teachers` to combine their logits while preserving joint CTC + attention training. Each target head (CTC, seq2seq, attention) can be toggled independently through `distillation.targets`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "from pathlib import Path\n",
+    "with open(Path('..') / 'Configs' / 'config.yml') as f:\n",
+    "    _config = yaml.safe_load(f)\n",
+    "_distillation_cfg = _config.get('distillation', {})\n",
+    "_distillation_cfg\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "48c765c9-c6ea-4a1a-b653-22514b84e3e2",
@@ -188,7 +210,7 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK ✓\")\n"
+    "print( \"All OK \u2713\")\n"
    ]
   },
   {
@@ -422,7 +444,7 @@
     "    predictions_cleaned = [' '.join(seq) for seq in predictions]\n",
     "    per = wer(references_cleaned, predictions_cleaned)\n",
     "\n",
-    "    print(f'Phoneme Error Rate: {per:.4f} {\"✓\" if per < best_model_per else \"✗\"}')\n",
+    "    print(f'Phoneme Error Rate: {per:.4f} {\"\u2713\" if per < best_model_per else \"\u2717\"}')\n",
     "    if per < best_model_per:\n",
     "        best_model_per = per\n",
     "        best_model = aux_model_file\n",
@@ -447,7 +469,7 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
    ]
   },
   {

--- a/distillation.py
+++ b/distillation.py
@@ -1,0 +1,487 @@
+"""Utilities for configuring and computing ensemble distillation losses."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+
+@dataclass
+class TargetConfig:
+    enabled: bool = True
+    weight: float = 1.0
+    loss: str = "kl"
+
+
+@dataclass
+class TeacherConfig:
+    name: str
+    storage_path: str
+    file_suffix: str = ".pt"
+    file_format: str = "pt"
+    path_style: str = "basename"
+    file_prefix: str = ""
+    include_extension: bool = False
+    weight: float = 1.0
+    temperature: float = 1.0
+    logits_format: str = "logits"
+    optional: bool = False
+    keys: Dict[str, Optional[str]] = None
+
+    def __post_init__(self):
+        self.file_format = str(self.file_format or "pt").lower()
+        self.path_style = str(self.path_style or "basename").lower()
+        self.logits_format = str(self.logits_format or "logits").lower()
+        self.keys = dict(self.keys or {})
+
+
+@dataclass
+class DistillationConfig:
+    enabled: bool = False
+    temperature: float = 1.0
+    loss_weight: float = 1.0
+    strict_loading: bool = False
+    missing_strategy: str = "skip"
+    targets: Dict[str, TargetConfig] = None
+    teachers: List[TeacherConfig] = None
+
+    def __post_init__(self):
+        self.targets = dict(self.targets or {})
+        self.teachers = list(self.teachers or [])
+        self.missing_strategy = str(self.missing_strategy or "skip").lower()
+        if self.missing_strategy not in {"skip", "error", "warn"}:
+            self.missing_strategy = "skip"
+
+
+_DEFAULT_TARGETS = {
+    "ctc": TargetConfig(enabled=True, weight=1.0, loss="kl"),
+    "s2s": TargetConfig(enabled=True, weight=1.0, loss="kl"),
+    "attention": TargetConfig(enabled=False, weight=1.0, loss="kl"),
+}
+
+
+def prepare_distillation_config(raw_config: Optional[Dict[str, Any]]) -> DistillationConfig:
+    """Return a normalised :class:`DistillationConfig` from raw YAML data."""
+    if not isinstance(raw_config, dict):
+        return DistillationConfig(enabled=False, targets=_DEFAULT_TARGETS)
+
+    enabled = bool(raw_config.get("enabled", False))
+    temperature = float(raw_config.get("temperature", 1.0))
+    loss_weight = float(raw_config.get("loss_weight", 1.0))
+    strict_loading = bool(raw_config.get("strict_loading", False))
+    missing_strategy = str(raw_config.get("missing_strategy", "skip")).lower()
+
+    targets_cfg = {}
+    raw_targets = raw_config.get("targets") or raw_config.get("apply_to") or {}
+    for key, default in _DEFAULT_TARGETS.items():
+        raw_target = raw_targets.get(key, {}) if isinstance(raw_targets, dict) else {}
+        if isinstance(raw_target, (int, float)):
+            raw_target = {"weight": float(raw_target), "enabled": True}
+        if isinstance(raw_target, bool):
+            raw_target = {"enabled": raw_target}
+        target = TargetConfig(
+            enabled=bool(raw_target.get("enabled", default.enabled)),
+            weight=float(raw_target.get("weight", default.weight)),
+            loss=str(raw_target.get("loss", default.loss)).lower(),
+        )
+        targets_cfg[key] = target
+
+    teachers_cfg: List[TeacherConfig] = []
+    raw_teachers = raw_config.get("teachers", [])
+    if isinstance(raw_teachers, dict):
+        raw_teachers = [raw_teachers]
+    for idx, teacher in enumerate(raw_teachers):
+        if not isinstance(teacher, dict):
+            continue
+        storage = teacher.get("storage", {})
+        if not isinstance(storage, dict):
+            storage = {}
+        storage_path = storage.get("path") or teacher.get("path")
+        if not storage_path:
+            continue
+        name = teacher.get("name") or f"teacher_{idx+1}"
+        weight = float(teacher.get("weight", 1.0))
+        teacher_temp = float(teacher.get("temperature", temperature))
+        logits_format = teacher.get("logits_format", teacher.get("format", "logits"))
+        optional = bool(teacher.get("optional", False))
+        file_suffix = storage.get("file_suffix", storage.get("suffix", ".pt"))
+        file_format = storage.get("file_format", storage.get("format", "pt"))
+        path_style = storage.get("path_style", storage.get("style", "basename"))
+        file_prefix = storage.get("file_prefix", storage.get("prefix", ""))
+        include_extension = bool(storage.get("include_extension", False))
+        keys = teacher.get("keys", {})
+        teachers_cfg.append(TeacherConfig(
+            name=name,
+            storage_path=storage_path,
+            file_suffix=file_suffix,
+            file_format=file_format,
+            path_style=path_style,
+            file_prefix=file_prefix,
+            include_extension=include_extension,
+            weight=weight,
+            temperature=teacher_temp,
+            logits_format=logits_format,
+            optional=optional,
+            keys=keys,
+        ))
+
+    return DistillationConfig(
+        enabled=enabled,
+        temperature=temperature,
+        loss_weight=loss_weight,
+        strict_loading=strict_loading,
+        missing_strategy=missing_strategy,
+        targets=targets_cfg,
+        teachers=teachers_cfg,
+    )
+
+
+class TeacherLogitsLoader:
+    """Load per-sample teacher logits from disk according to a config."""
+
+    def __init__(self, config: DistillationConfig):
+        self.config = config or DistillationConfig(enabled=False, targets=_DEFAULT_TARGETS)
+        self.enabled = bool(self.config.enabled and self.config.teachers)
+
+    def _resolve_sample_stem(self, audio_path: str, teacher: TeacherConfig) -> str:
+        if teacher.path_style == "relative":
+            base = os.path.splitext(audio_path)[0]
+            base = base.replace("\\", os.sep)
+        else:
+            base = os.path.splitext(os.path.basename(audio_path))[0]
+        if teacher.include_extension:
+            base = os.path.basename(audio_path)
+        return f"{teacher.file_prefix}{base}{teacher.file_suffix}"
+
+    def _load_payload(self, file_path: str, teacher: TeacherConfig):
+        fmt = teacher.file_format
+        if fmt == "pt":
+            return torch.load(file_path, map_location="cpu")
+        if fmt == "pth":
+            return torch.load(file_path, map_location="cpu")
+        if fmt == "npz":
+            return np.load(file_path, allow_pickle=True)
+        if fmt == "npy":
+            return np.load(file_path, allow_pickle=True)
+        raise ValueError(f"Unsupported teacher file format: {fmt}")
+
+    def _extract_value(self, payload, key: Optional[str]):
+        if key is None:
+            return None
+        if isinstance(payload, dict):
+            return payload.get(key)
+        if isinstance(payload, np.lib.npyio.NpzFile):
+            if key in payload.files:
+                return payload[key]
+            return None
+        if hasattr(payload, key):
+            return getattr(payload, key)
+        if isinstance(payload, (list, tuple)):
+            try:
+                key_int = int(key)
+            except (TypeError, ValueError):
+                return None
+            if 0 <= key_int < len(payload):
+                return payload[key_int]
+        return None
+
+    def fetch(self, audio_path: str, mel_frames: int = None, text_tokens: int = None):
+        if not self.enabled:
+            return None
+
+        aggregated = {"ctc": [], "s2s": [], "attention": []}
+        for teacher in self.config.teachers:
+            sample_name = self._resolve_sample_stem(audio_path, teacher)
+            file_path = os.path.join(teacher.storage_path, sample_name)
+            if not os.path.exists(file_path):
+                if self.config.strict_loading and not teacher.optional:
+                    raise FileNotFoundError(f"Teacher logits missing: {file_path}")
+                if self.config.missing_strategy == "warn" and not teacher.optional:
+                    print(f"[distillation] Missing teacher logits for {audio_path} -> {file_path}")
+                continue
+            try:
+                payload = self._load_payload(file_path, teacher)
+            except Exception as exc:  # pylint: disable=broad-except
+                if self.config.strict_loading and not teacher.optional:
+                    raise
+                print(f"[distillation] Failed to load {file_path}: {exc}")
+                continue
+
+            keys = teacher.keys or {}
+            entry = {}
+            for target_key in ("ctc", "s2s", "attention"):
+                key_name = keys.get(target_key)
+                if not key_name:
+                    continue
+                raw_value = self._extract_value(payload, key_name)
+                if raw_value is None:
+                    continue
+                tensor = torch.as_tensor(raw_value).float()
+                if tensor.dim() >= 3 and tensor.size(0) == 1:
+                    tensor = tensor.squeeze(0)
+                length_key = keys.get(f"{target_key}_length")
+                target_length = self._extract_value(payload, length_key) if length_key else None
+                if isinstance(target_length, (list, tuple, np.ndarray)):
+                    if len(target_length) > 0:
+                        target_length = int(target_length[0])
+                    else:
+                        target_length = None
+                if torch.is_tensor(target_length):
+                    target_length = int(target_length.item())
+                entry[target_key] = {
+                    "logits": tensor,
+                    "length": target_length,
+                    "name": teacher.name,
+                    "weight": float(teacher.weight),
+                    "temperature": float(teacher.temperature),
+                    "format": teacher.logits_format,
+                }
+            for key, value in entry.items():
+                aggregated[key].append(value)
+
+        if not any(aggregated[key] for key in aggregated):
+            return None
+        return aggregated
+
+
+class EnsembleDistillationHelper:
+    """Compute ensemble distillation losses for the trainer."""
+
+    def __init__(self, config: DistillationConfig, device: torch.device):
+        self.config = config
+        self.device = device
+        self.temperature = float(config.temperature)
+        self.loss_weight = float(config.loss_weight)
+
+    def is_enabled(self, key: str) -> bool:
+        target_cfg = self.config.targets.get(key)
+        return bool(self.config.enabled and target_cfg and target_cfg.enabled and target_cfg.weight > 0.0)
+
+    def target_weight(self, key: str) -> float:
+        target_cfg = self.config.targets.get(key)
+        if target_cfg is None:
+            return 0.0
+        return float(target_cfg.weight)
+
+    def target_loss_type(self, key: str) -> str:
+        target_cfg = self.config.targets.get(key)
+        if target_cfg is None:
+            return "kl"
+        return target_cfg.loss
+
+    def _aggregate_probabilities(
+        self,
+        teachers: Sequence[Dict[str, Any]],
+        reference: torch.Tensor,
+        key: str,
+    ) -> Optional[torch.Tensor]:
+        if not teachers:
+            return None
+
+        valid_tensors: List[torch.Tensor] = []
+        weights: List[float] = []
+        min_time = reference.size(0)
+        vocab_size = reference.size(-1)
+        for entry in teachers:
+            tensor = entry.get("logits")
+            if tensor is None:
+                continue
+            tensor = torch.as_tensor(tensor).float()
+            if tensor.dim() == 3 and tensor.size(0) == 1:
+                tensor = tensor.squeeze(0)
+            if tensor.size(-1) != vocab_size:
+                continue
+            entry_length = entry.get("length")
+            if entry_length is None:
+                entry_length = tensor.size(0)
+            min_time = min(min_time, int(entry_length), tensor.size(0))
+            weights.append(float(entry.get("weight", 1.0)))
+            valid_tensors.append(tensor)
+
+        if not valid_tensors or min_time <= 0:
+            return None
+
+        stacked = []
+        for tensor, weight, entry in zip(valid_tensors, weights, teachers):
+            tensor = tensor[:min_time].to(self.device)
+            fmt = entry.get("format", "logits")
+            teacher_temp = float(entry.get("temperature", self.temperature))
+            if fmt == "probs":
+                probs = tensor
+                probs = probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-8)
+            else:
+                probs = torch.softmax(tensor / max(teacher_temp, 1e-6), dim=-1)
+            stacked.append(probs * weight)
+        summed = torch.stack(stacked, dim=0).sum(dim=0)
+        weight_total = sum(weights)
+        if weight_total <= 0:
+            weight_total = len(stacked)
+        aggregated = summed / max(weight_total, 1e-6)
+        aggregated = aggregated / aggregated.sum(dim=-1, keepdim=True).clamp_min(1e-8)
+        return aggregated
+
+    def _aggregate_raw(self, teachers: Sequence[Dict[str, Any]], reference: torch.Tensor) -> Optional[torch.Tensor]:
+        if not teachers:
+            return None
+        valid_tensors: List[torch.Tensor] = []
+        weights: List[float] = []
+        min_time = reference.size(0)
+        feature_size = reference.size(-1)
+        for entry in teachers:
+            tensor = entry.get("logits")
+            if tensor is None:
+                continue
+            tensor = torch.as_tensor(tensor).float()
+            if tensor.dim() == 3 and tensor.size(0) == 1:
+                tensor = tensor.squeeze(0)
+            if tensor.size(-1) != feature_size:
+                continue
+            entry_length = entry.get("length")
+            if entry_length is None:
+                entry_length = tensor.size(0)
+            min_time = min(min_time, int(entry_length), tensor.size(0))
+            weights.append(float(entry.get("weight", 1.0)))
+            valid_tensors.append(tensor)
+
+        if not valid_tensors or min_time <= 0:
+            return None
+
+        stacked = []
+        for tensor, weight in zip(valid_tensors, weights):
+            stacked.append(tensor[:min_time].to(self.device) * weight)
+        summed = torch.stack(stacked, dim=0).sum(dim=0)
+        weight_total = sum(weights)
+        if weight_total <= 0:
+            weight_total = len(stacked)
+        aggregated = summed / max(weight_total, 1e-6)
+        return aggregated
+
+    def _sequence_mask(self, length: int, max_len: int) -> torch.Tensor:
+        return torch.arange(max_len, device=self.device) < max(0, int(length))
+
+    def _kl_loss(
+        self,
+        student_logits: torch.Tensor,
+        teacher_entries: Sequence[Dict[str, Any]],
+        length: int,
+        key: str,
+    ) -> Optional[torch.Tensor]:
+        aggregated = self._aggregate_probabilities(teacher_entries, student_logits, key)
+        if aggregated is None:
+            return None
+        max_time = aggregated.size(0)
+        student_slice = student_logits[:max_time]
+        length = min(int(length), max_time)
+        if length <= 0:
+            return None
+        mask = self._sequence_mask(length, max_time).float()
+        student_log_probs = torch.log_softmax(student_slice / max(self.temperature, 1e-6), dim=-1)
+        per_step = F.kl_div(student_log_probs, aggregated, reduction="none").sum(dim=-1)
+        per_step = per_step * mask
+        normalizer = mask.sum().clamp_min(1.0)
+        loss = per_step.sum() / normalizer
+        loss = loss * (self.temperature ** 2)
+        return loss
+
+    def _mse_loss(
+        self,
+        student_tensor: torch.Tensor,
+        teacher_entries: Sequence[Dict[str, Any]],
+        length: int,
+    ) -> Optional[torch.Tensor]:
+        aggregated = self._aggregate_raw(teacher_entries, student_tensor)
+        if aggregated is None:
+            return None
+        max_time = aggregated.size(0)
+        student_slice = student_tensor[:max_time]
+        length = min(int(length), max_time)
+        if length <= 0:
+            return None
+        mask = self._sequence_mask(length, max_time).float().unsqueeze(-1)
+        squared = (student_slice - aggregated) ** 2
+        squared = squared * mask
+        normalizer = mask.sum().clamp_min(1.0)
+        loss = squared.sum() / normalizer
+        return loss
+
+    def compute_losses(
+        self,
+        outputs: Dict[str, torch.Tensor],
+        teacher_batch: Optional[Sequence[Optional[Dict[str, Any]]]],
+        mel_lengths: torch.Tensor,
+        text_lengths: torch.Tensor,
+    ) -> Tuple[Optional[torch.Tensor], Dict[str, float]]:
+        if not self.config.enabled:
+            return None, {}
+        if teacher_batch is None:
+            return None, {}
+
+        batch_size = len(teacher_batch)
+        losses: Dict[str, float] = {}
+        total_loss = None
+
+        # CTC distillation
+        ctc_logits = outputs.get("ctc_logits")
+        if self.is_enabled("ctc") and isinstance(ctc_logits, torch.Tensor):
+            per_sample_losses = []
+            for idx in range(batch_size):
+                teachers = (teacher_batch[idx] or {}).get("ctc", [])
+                if not teachers:
+                    continue
+                sample_loss = self._kl_loss(ctc_logits[idx], teachers, mel_lengths[idx], "ctc")
+                if sample_loss is not None:
+                    per_sample_losses.append(sample_loss)
+            if per_sample_losses:
+                stacked = torch.stack(per_sample_losses)
+                loss_ctc = stacked.mean() * self.target_weight("ctc")
+                losses["distillation/ctc"] = float(loss_ctc.item())
+                total_loss = loss_ctc if total_loss is None else total_loss + loss_ctc
+
+        # Seq2Seq distillation
+        s2s_logits = outputs.get("s2s_logits")
+        if self.is_enabled("s2s") and isinstance(s2s_logits, torch.Tensor):
+            per_sample_losses = []
+            for idx in range(batch_size):
+                teachers = (teacher_batch[idx] or {}).get("s2s", [])
+                if not teachers:
+                    continue
+                sample_loss = self._kl_loss(s2s_logits[idx], teachers, text_lengths[idx], "s2s")
+                if sample_loss is not None:
+                    per_sample_losses.append(sample_loss)
+            if per_sample_losses:
+                stacked = torch.stack(per_sample_losses)
+                loss_s2s = stacked.mean() * self.target_weight("s2s")
+                losses["distillation/s2s"] = float(loss_s2s.item())
+                total_loss = loss_s2s if total_loss is None else total_loss + loss_s2s
+
+        # Attention distillation
+        s2s_attn = outputs.get("s2s_attn")
+        if self.is_enabled("attention") and isinstance(s2s_attn, torch.Tensor):
+            per_sample_losses = []
+            loss_type = self.target_loss_type("attention")
+            for idx in range(batch_size):
+                teachers = (teacher_batch[idx] or {}).get("attention", [])
+                if not teachers:
+                    continue
+                if loss_type == "mse":
+                    sample_loss = self._mse_loss(s2s_attn[idx], teachers, text_lengths[idx])
+                else:
+                    sample_loss = self._kl_loss(s2s_attn[idx], teachers, text_lengths[idx], "attention")
+                if sample_loss is not None:
+                    per_sample_losses.append(sample_loss)
+            if per_sample_losses:
+                stacked = torch.stack(per_sample_losses)
+                loss_attn = stacked.mean() * self.target_weight("attention")
+                losses["distillation/attention"] = float(loss_attn.item())
+                total_loss = loss_attn if total_loss is None else total_loss + loss_attn
+
+        if total_loss is None:
+            return None, {}
+        losses["distillation/total_unscaled"] = float(total_loss.item())
+        total_loss = total_loss * self.loss_weight
+        losses["distillation/total"] = float(total_loss.item())
+        return total_loss, losses

--- a/meldataset.py
+++ b/meldataset.py
@@ -22,6 +22,7 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 from text_utils import TextCleaner
+from distillation import DistillationConfig, TeacherLogitsLoader, prepare_distillation_config
 np.random.seed(1)
 random.seed(1)
 DEFAULT_DICT_PATH = osp.join(osp.dirname(__file__), 'word_index_dict.txt')
@@ -159,7 +160,8 @@ class MelDataset(torch.utils.data.Dataset):
                      "n_mels": 80
                  },
                  spec_augment_params=None,
-                 validation=False
+                 validation=False,
+                 distillation=None,
                 ):
 
         self.data_list = data_list
@@ -180,6 +182,14 @@ class MelDataset(torch.utils.data.Dataset):
 
         # https://github.com/yl4579/StyleTTS/issues/57
         self.mean, self.std = -4, 4
+
+        if isinstance(distillation, dict):
+            distillation = prepare_distillation_config(distillation)
+        if isinstance(distillation, DistillationConfig):
+            self.distillation_loader = TeacherLogitsLoader(distillation)
+        else:
+            self.distillation_loader = TeacherLogitsLoader(DistillationConfig(enabled=False))
+        self.distillation_enabled = self.distillation_loader.enabled
 
     def __len__(self):
         return len(self.data_list)
@@ -206,7 +216,15 @@ class MelDataset(torch.utils.data.Dataset):
             length_feature = acoustic_feature.size(1)
             acoustic_feature = acoustic_feature[:, :(length_feature - length_feature % 2)]
 
-            return wave_tensor, acoustic_feature, text_tensor, speaker_id
+            distillation_targets = None
+            if self.distillation_enabled:
+                distillation_targets = self._load_distillation_targets(
+                    wave_path,
+                    mel_frames=acoustic_feature.size(1),
+                    text_tokens=text_tensor.size(0),
+                )
+
+            return wave_tensor, acoustic_feature, text_tensor, speaker_id, distillation_targets
         except Exception as e:
             try:
                 wave_path, text, speaker_id = data
@@ -217,6 +235,18 @@ class MelDataset(torch.utils.data.Dataset):
             # Fallback to another index to keep training going
             new_idx = (idx + 1) % len(self.data_list)
             return self.__getitem__(new_idx)
+
+    def _load_distillation_targets(self, wave_path, mel_frames=None, text_tokens=None):
+        try:
+            targets = self.distillation_loader.fetch(
+                wave_path,
+                mel_frames=mel_frames,
+                text_tokens=text_tokens,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.warning("Failed to fetch distillation targets for %s: %s", wave_path, exc)
+            targets = None
+        return targets
 
     def _load_tensor(self, data):
         wave_path, text, speaker_id = data
@@ -282,10 +312,11 @@ class Collater(object):
       return_wave (bool): if true, will return the wave data along with spectrogram. 
     """
 
-    def __init__(self, return_wave=False, return_speaker_ids=False):
+    def __init__(self, return_wave=False, return_speaker_ids=False, return_distillation=False):
         self.text_pad_index = 0
         self.return_wave = return_wave
         self.return_speaker_ids = return_speaker_ids
+        self.return_distillation = return_distillation
 
     def __call__(self, batch):
         batch_size = len(batch)
@@ -304,7 +335,14 @@ class Collater(object):
         input_lengths = torch.zeros(batch_size).long()
         output_lengths = torch.zeros(batch_size).long()
         speaker_ids = torch.zeros(batch_size).long()
-        for bid, (_, mel, text, speaker_id) in enumerate(batch):
+        distillation_batch = []
+
+        for bid, sample in enumerate(batch):
+            wave = sample[0]
+            mel = sample[1]
+            text = sample[2]
+            speaker_id = sample[3]
+            distillation_entry = sample[4] if len(sample) > 4 else None
             mel_size = mel.size(1)
             text_size = text.size(0)
             mels[bid, :, :mel_size] = mel
@@ -313,11 +351,16 @@ class Collater(object):
             output_lengths[bid] = mel_size
             speaker_ids[bid] = int(speaker_id)
             assert(text_size < (mel_size//2))
+            if self.return_distillation:
+                distillation_batch.append(distillation_entry)
 
         outputs = [texts, input_lengths, mels, output_lengths]
 
         if self.return_speaker_ids:
             outputs.append(speaker_ids)
+
+        if self.return_distillation:
+            outputs.append(distillation_batch)
 
         if self.return_wave:
             waves = [b[0] for b in batch]

--- a/train.py
+++ b/train.py
@@ -3,6 +3,7 @@ from optimizers import build_optimizer
 from utils import *
 from models import build_model
 from trainer import Trainer
+from distillation import prepare_distillation_config
 
 import os
 import os.path as osp
@@ -239,6 +240,9 @@ def main(config_path):
 
     raw_train_list, raw_val_list = get_data_path_list(train_path, val_path)
 
+    distillation_config = prepare_distillation_config(cfg_get_nested(config, 'distillation', {}))
+    dataset_params['distillation'] = distillation_config
+
     train_entries, train_durations = prepare_data_list(raw_train_list, root_path="")
     val_entries, val_durations = prepare_data_list(raw_val_list, root_path="")
 
@@ -252,7 +256,10 @@ def main(config_path):
     val_num_workers = int(dataloader_params.get('val_num_workers', 2))
     train_bucket_sampler_config = dataloader_params.get('train_bucket_sampler', {})
 
-    collate_config = {'return_speaker_ids': True}
+    collate_config = {
+        'return_speaker_ids': True,
+        'return_distillation': bool(distillation_config.enabled and distillation_config.teachers),
+    }
 
     sorted_train_dataloader = build_dataloader(train_list_sorted,
                                         batch_size=batch_size,
@@ -402,6 +409,7 @@ def main(config_path):
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
                     entropy_regularization_config=entropy_regularization_config,
+                    distillation_config=distillation_config,
                     steps_per_epoch=steps_per_epoch
                     )
 

--- a/trainer.py
+++ b/trainer.py
@@ -9,10 +9,12 @@ from collections import defaultdict
 import numpy as np
 import torch
 from torch import nn
+import torch.nn.functional as F
 from PIL import Image
 from tqdm import tqdm
 
 from utils import calc_wer
+from distillation import DistillationConfig, EnsembleDistillationHelper, prepare_distillation_config
 
 import logging
 from torch.distributions import Beta
@@ -51,6 +53,7 @@ class Trainer(object):
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
                  entropy_regularization_config=None,
+                 distillation_config=None,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -109,6 +112,15 @@ class Trainer(object):
         self.entropy_regularization_eps = float(entropy_cfg.get('eps', 1.0e-6))
         targets_cfg = entropy_cfg.get('targets', {}) if isinstance(entropy_cfg, dict) else {}
         self.entropy_regularization_targets = self._parse_entropy_regularization_targets(targets_cfg, entropy_cfg)
+
+        if isinstance(distillation_config, dict):
+            distillation_config = prepare_distillation_config(distillation_config)
+        elif not isinstance(distillation_config, DistillationConfig):
+            distillation_config = prepare_distillation_config(None)
+
+        self.distillation_config = distillation_config
+        self.distillation_helper = EnsembleDistillationHelper(distillation_config, self.device)
+        self.expect_distillation = bool(distillation_config.enabled and distillation_config.teachers)
 
         self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
@@ -597,11 +609,24 @@ class Trainer(object):
         batch = processed_batch
 
         text_input, text_input_length, mel_input, mel_input_length = batch[:4]
-        if len(batch) > 4:
-            speaker_ids = batch[4]
-        else:
-            speaker_ids = torch.zeros(text_input.size(0), device=self.device, dtype=torch.long)
-        speaker_ids = speaker_ids.long()
+
+        batch_size = text_input.size(0)
+        speaker_ids = torch.zeros(batch_size, device=self.device, dtype=torch.long)
+        distillation_targets = None
+
+        extra_index = 4
+        if len(batch) > extra_index and isinstance(batch[extra_index], torch.Tensor) and batch[extra_index].dtype == torch.long:
+            speaker_ids = batch[extra_index].long()
+            extra_index += 1
+
+        if self.expect_distillation and len(batch) > extra_index:
+            candidate = batch[extra_index]
+            if isinstance(candidate, (list, tuple)):
+                distillation_targets = list(candidate)
+                extra_index += 1
+
+        if distillation_targets is None and self.expect_distillation:
+            distillation_targets = [None for _ in range(batch_size)]
 
         mix_metadata = None
         if self.mixspeech_enabled and self.model.training:
@@ -760,6 +785,18 @@ class Trainer(object):
         else:
             pron_loss = torch.zeros(1, device=self.device)
 
+        if self.distillation_config.enabled:
+            distill_loss, distill_logs = self.distillation_helper.compute_losses(
+                model_outputs,
+                distillation_targets,
+                mel_input_length,
+                text_input_length,
+            )
+            if distill_loss is not None:
+                total_loss = total_loss + distill_loss
+                for key, value in distill_logs.items():
+                    losses[key] = value
+
         if self.use_diagonal_attention_prior and s2s_attn is not None:
             loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
             total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
@@ -825,10 +862,23 @@ class Trainer(object):
             batch = processed_batch
 
             text_input, text_input_length, mel_input, mel_input_length = batch[:4]
-            if len(batch) > 4:
-                speaker_ids = batch[4].long()
-            else:
-                speaker_ids = torch.zeros(text_input.size(0), device=self.device, dtype=torch.long)
+            batch_size = text_input.size(0)
+            speaker_ids = torch.zeros(batch_size, device=self.device, dtype=torch.long)
+            distillation_targets = None
+
+            extra_index = 4
+            if len(batch) > extra_index and isinstance(batch[extra_index], torch.Tensor) and batch[extra_index].dtype == torch.long:
+                speaker_ids = batch[extra_index].long()
+                extra_index += 1
+
+            if self.expect_distillation and len(batch) > extra_index:
+                candidate = batch[extra_index]
+                if isinstance(candidate, (list, tuple)):
+                    distillation_targets = list(candidate)
+                    extra_index += 1
+
+            if distillation_targets is None and self.expect_distillation:
+                distillation_targets = [None for _ in range(batch_size)]
             mel_input_length = mel_input_length // (2 ** self.model.n_down)
             future_mask = self.model.get_future_mask(
                 mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
@@ -960,6 +1010,18 @@ class Trainer(object):
                     pron_pred = torch.argmax(pron_logits, dim=2)
                     pron_acc = self._sequence_accuracy(pron_pred, pron_targets)
                     eval_losses['eval/pronunciation_error_acc'].append(pron_acc)
+
+            if self.distillation_config.enabled:
+                distill_loss, distill_logs = self.distillation_helper.compute_losses(
+                    model_outputs,
+                    distillation_targets,
+                    mel_input_length,
+                    text_input_length,
+                )
+                if distill_loss is not None:
+                    total_eval_loss = total_eval_loss + distill_loss
+                    for key, value in distill_logs.items():
+                        eval_losses[f'eval/{key}'].append(value)
 
             eval_losses["eval/loss"].append(total_eval_loss.item())
 


### PR DESCRIPTION
## Summary
- add a dedicated distillation helper module for normalising teacher configs and computing ensemble losses
- wire distillation targets through the dataset, trainer, and training script with new YAML configuration toggles
- refresh all utility notebooks with guidance and code cells for the new distillation options

## Testing
- python -m compileall distillation.py trainer.py meldataset.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d6d8ea1c3c8332afdd82829445f35e