### PR TITLE
Add configurable random frame drop to SpecAugment

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -106,6 +106,12 @@ dataset_params:
     time_mask_param: 50
     num_freq_masks: 2
     num_time_masks: 2
+    random_frame_drop:
+      enabled: false
+      drop_prob: 0.25
+      min_drop_rate: 0.05
+      max_drop_rate: 0.1
+      replacement: zero
 
 dataloader_params:
   train_num_workers: 8

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ dataset_params:
     time_mask_param: 50
     num_freq_masks: 2
     num_time_masks: 2
+    random_frame_drop:
+      enabled: false   # toggle the random frame dropping extension
+      drop_prob: 0.25  # probability of applying the frame drop on a sample
+      min_drop_rate: 0.05
+      max_drop_rate: 0.1
+      replacement: zero  # or "mean" to fill with per-bin mean energy
 
 loss_weights:
   ctc: 0.8             # reduce to 0.5-0.7 for extremely small datasets

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -264,7 +264,7 @@
     "## CTC entropy statistics\n",
     "- mean_maxprob often ends up > 0.6;\n",
     "- mean_entropy should drop well below log(V);\n",
-    "- mean_blank_rate typically sits around 0.6–0.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
+    "- mean_blank_rate typically sits around 0.6\u20130.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
    ]
   },
   {
@@ -366,6 +366,34 @@
     "        weight: 0.0\n",
     "        length_normalize: true\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -253,7 +253,7 @@
    "metadata": {},
    "source": [
     "## Mean CTC loss evaluation\n",
-    "- simple early-stopping signal; shouldn’t diverge vs train."
+    "- simple early-stopping signal; shouldn\u2019t diverge vs train."
    ]
   },
   {
@@ -365,6 +365,34 @@
     "        weight: 0.0\n",
     "        length_normalize: true\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -351,7 +351,7 @@
    "metadata": {},
    "source": [
     "### Diagonal Attention Score\n",
-    "- scores > 0.6–0.7 are usually good; trending higher across training is a healthy sign."
+    "- scores > 0.6\u20130.7 are usually good; trending higher across training is a healthy sign."
    ]
   },
   {
@@ -416,6 +416,34 @@
     "        weight: 0.0\n",
     "        length_normalize: true\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -260,8 +260,8 @@
    "metadata": {},
    "source": [
     "## Duration statistics computation\n",
-    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz ≈ 12.5 ms/frame → 8–15 frames/phone is typical for EN; tonal languages can vary).\n",
-    "- extremely short (1–2 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
+    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz \u2248 12.5 ms/frame \u2192 8\u201315 frames/phone is typical for EN; tonal languages can vary).\n",
+    "- extremely short (1\u20132 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
    ]
   },
   {
@@ -390,6 +390,34 @@
     "        weight: 0.0\n",
     "        length_normalize: true\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -538,6 +538,34 @@
     "        length_normalize: true\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -485,6 +485,34 @@
     "        length_normalize: true\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -373,6 +373,34 @@
     "        length_normalize: true\n",
     "```"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -188,7 +188,7 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK ✓\")\n"
+    "print( \"All OK \u2713\")\n"
    ]
   },
   {
@@ -422,7 +422,7 @@
     "    predictions_cleaned = [' '.join(seq) for seq in predictions]\n",
     "    per = wer(references_cleaned, predictions_cleaned)\n",
     "\n",
-    "    print(f'Phoneme Error Rate: {per:.4f} {\"✓\" if per < best_model_per else \"✗\"}')\n",
+    "    print(f'Phoneme Error Rate: {per:.4f} {\"\u2713\" if per < best_model_per else \"\u2717\"}')\n",
     "    if per < best_model_per:\n",
     "        best_model_per = per\n",
     "        best_model = aux_model_file\n",
@@ -447,7 +447,7 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
    ]
   },
   {
@@ -490,6 +490,34 @@
     "        weight: 0.0\n",
     "        length_normalize: true\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Random frame drop configuration\n",
+    "Use the helper below to enable or tweak the random frame dropping extension of SpecAugment when running notebook experiments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_random_frame_drop(config, *, enabled=False, drop_prob=0.0, min_drop_rate=0.0, max_drop_rate=0.1, replacement='zero'):\n",
+    "    \"\"\"Update the configuration dict with random frame drop settings for SpecAugment.\"\"\"\n",
+    "    dataset_cfg = config.setdefault('dataset_params', {})\n",
+    "    spec_cfg = dataset_cfg.setdefault('spec_augment', {})\n",
+    "    spec_cfg['random_frame_drop'] = {\n",
+    "        'enabled': bool(enabled),\n",
+    "        'drop_prob': float(drop_prob),\n",
+    "        'min_drop_rate': float(min_drop_rate),\n",
+    "        'max_drop_rate': float(max_drop_rate),\n",
+    "        'replacement': str(replacement),\n",
+    "    }\n",
+    "    return config\n"
    ]
   }
  ],

--- a/meldataset.py
+++ b/meldataset.py
@@ -41,19 +41,41 @@ DEFAULT_DICT_PATH = osp.join(osp.dirname(__file__), 'word_index_dict.txt')
 
 
 class SpecAugment:
-    """Simple SpecAugment implementation for log-mel spectrograms."""
+    """Simple SpecAugment implementation for log-mel spectrograms with optional frame dropping."""
 
     def __init__(self,
                  freq_mask_param=27,
                  time_mask_param=40,
                  num_freq_masks=2,
                  num_time_masks=2,
-                 apply_prob=1.0):
+                 apply_prob=1.0,
+                 random_frame_drop_params=None):
         self.freq_mask_param = int(freq_mask_param)
         self.time_mask_param = int(time_mask_param)
         self.num_freq_masks = int(num_freq_masks)
         self.num_time_masks = int(num_time_masks)
         self.apply_prob = float(apply_prob)
+
+        if random_frame_drop_params is None:
+            random_frame_drop_params = {}
+        self.frame_drop_enabled = bool(random_frame_drop_params.get('enabled', False))
+        self.frame_drop_prob = float(random_frame_drop_params.get('drop_prob', 0.0))
+        min_rate = float(random_frame_drop_params.get('min_drop_rate', 0.0))
+        max_rate = float(random_frame_drop_params.get('max_drop_rate', min_rate))
+        min_rate = min(max(min_rate, 0.0), 1.0)
+        max_rate = min(max(max_rate, 0.0), 1.0)
+        if max_rate < min_rate:
+            max_rate = min_rate
+        self.frame_drop_min_rate = min_rate
+        self.frame_drop_max_rate = max_rate
+        replacement = str(random_frame_drop_params.get('replacement', 'zero')).lower()
+        if replacement not in {'zero', 'mean'}:
+            logger.warning(
+                "Unsupported random frame drop replacement '%s'. Falling back to 'zero'.",
+                replacement
+            )
+            replacement = 'zero'
+        self.frame_drop_replacement = replacement
 
         self._freq_mask = T.FrequencyMasking(freq_mask_param=self.freq_mask_param)
         self._time_mask = T.TimeMasking(time_mask_param=self.time_mask_param)
@@ -75,10 +97,48 @@ class SpecAugment:
         for _ in range(max(0, self.num_time_masks)):
             augmented = self._time_mask(augmented)
 
+        if self.frame_drop_enabled:
+            augmented = self._apply_random_frame_drop(augmented)
+
         if squeeze:
             augmented = augmented.squeeze(0)
 
         return augmented
+
+    def _apply_random_frame_drop(self, tensor: torch.Tensor) -> torch.Tensor:
+        if self.frame_drop_prob <= 0.0 or self.frame_drop_max_rate <= 0.0:
+            return tensor
+
+        if self.frame_drop_prob < 1.0 and random.random() > self.frame_drop_prob:
+            return tensor
+
+        time_dim = tensor.size(-1)
+        if time_dim <= 0:
+            return tensor
+
+        drop_rate = random.uniform(self.frame_drop_min_rate, self.frame_drop_max_rate)
+        if drop_rate <= 0.0:
+            return tensor
+
+        num_frames = max(1, int(round(drop_rate * time_dim)))
+        num_frames = min(num_frames, time_dim)
+
+        if num_frames == time_dim:
+            drop_indices = torch.arange(time_dim, device=tensor.device)
+        else:
+            drop_indices = torch.randperm(time_dim, device=tensor.device)[:num_frames]
+
+        drop_indices, _ = torch.sort(drop_indices)
+
+        tensor = tensor.clone()
+
+        if self.frame_drop_replacement == 'mean':
+            fill = tensor.mean(dim=-1, keepdim=True)
+            tensor[:, :, drop_indices] = fill.expand(-1, -1, num_frames)
+            return tensor
+
+        tensor.index_fill_(-1, drop_indices, 0.0)
+        return tensor
 
 
 class LengthAwareBatchSampler(Sampler):
@@ -173,7 +233,12 @@ class MelDataset(torch.utils.data.Dataset):
         self.spec_augment = None
         if spec_augment_params and not validation:
             try:
-                self.spec_augment = SpecAugment(**spec_augment_params)
+                spec_params = dict(spec_augment_params)
+                random_frame_drop_cfg = spec_params.pop('random_frame_drop', None)
+                self.spec_augment = SpecAugment(
+                    **spec_params,
+                    random_frame_drop_params=random_frame_drop_cfg
+                )
             except TypeError:
                 logger.warning(f"Invalid SpecAugment configuration: {spec_augment_params}. Skipping augmentation.")
                 self.spec_augment = None


### PR DESCRIPTION
## Summary
- extend SpecAugment with configurable random frame dropping including fill strategies
- expose the new augmentation controls in the default config and documentation
- add helper cells to every Utils notebook so experiments can toggle the new augmentation

## Testing
- python -m compileall meldataset.py

------
https://chatgpt.com/codex/tasks/task_e_68d704d981808332ab081992f1d3aad4