### PR TITLE
Add configurable mixed-precision training support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -82,6 +82,17 @@ optimizer_params:
   lr: 0.0005
   pct_start: 0.1
 
+precision:
+  mixed_precision:
+    enabled: false
+    dtype: "float16"  # options: float16, bfloat16
+    grad_scaler:
+      enabled: true
+      init_scale: 65536.0
+      growth_factor: 2.0
+      backoff_factor: 0.5
+      growth_interval: 2000
+
 # this is a very basic early stopping based off learning rate - when it falls to 0 and remains there for 3 epochs, the training stops
 enable_early_stopping: True
 

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -50,7 +50,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({'type': 'CUDA', 'available': False, 'name': 'N/A'})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -84,6 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# import packages, define helper utilities\n",
     "import os\n",
     "import yaml\n",
@@ -204,7 +206,22 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -275,7 +292,9 @@
     "model_path = os.path.join(checkpoint_dir, ckpt_files[-1])\n",
     "\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "print(f'model --> {model_path}')\n",
     "print(f'config --> {config_path}')\n",
@@ -299,7 +318,7 @@
     "## CTC entropy statistics\n",
     "- mean_maxprob often ends up > 0.6;\n",
     "- mean_entropy should drop well below log(V);\n",
-    "- mean_blank_rate typically sits around 0.6\u20130.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
+    "- mean_blank_rate typically sits around 0.6–0.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
    ]
   },
   {
@@ -326,7 +345,8 @@
     "        mels = mels.to(device)\n",
     "        mel_lens = mel_lens.to(torch.long)\n",
     "\n",
-    "        outputs = model(mels)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get('logits_ctc')\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -51,7 +51,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({\"type\": \"CUDA\", \"available\": False, \"name\": \"N/A\"})\n",
-    "devices\n"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -86,6 +87,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "\n",
     "# import packages, define helper utilities\n",
     "import os\n",
@@ -205,7 +207,22 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -269,7 +286,9 @@
     "model_path = os.path.join(checkpoint_dir, ckpt_files[-1])\n",
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "dev_loader = build_dev_dataloader(config, device)\n",
     "print(f\"model --> {model_path}\")\n",
@@ -290,7 +309,7 @@
    "metadata": {},
    "source": [
     "## Mean CTC loss evaluation\n",
-    "- simple early-stopping signal; shouldn\u2019t diverge vs train."
+    "- simple early-stopping signal; shouldn’t diverge vs train."
    ]
   },
   {
@@ -322,7 +341,8 @@
     "        text_lens = text_lens.to(torch.long)\n",
     "        mel_lens = mel_lens.to(torch.long)\n",
     "\n",
-    "        outputs = model(mels)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get(\"logits_ctc\")\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -49,7 +49,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({'type': 'CUDA', 'available': False, 'name': 'N/A'})\n",
-    "devices\n"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -76,6 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "def resolve_dataset_params(config, base_overrides=None):\n",
     "    dataset_params = {\n",
     "        'dict_path': cfg_get_nested(config, 'phoneme_maps_path', 'Data/word_index_dict.txt'),\n",
@@ -105,7 +107,23 @@
     "    if base_overrides:\n",
     "        dataset_params.update(base_overrides)\n",
     "    return dataset_params\n",
-    "\n"
+    "\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -138,6 +156,7 @@
     "print(f'dictionary --> {phoneme_source}')\n",
     "\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
     "model, token_map = load_asr_model_from_config(config, model_path, device)\n",
     "\n",
     "dev_loader, val_entries = build_dev_dataloader_from_config(config, device)\n",
@@ -190,7 +209,8 @@
     "        reduced_mel_lens = torch.clamp(mel_lens // downsample, min=1)\n",
     "        mel_mask = model.length_to_mask(reduced_mel_lens)\n",
     "\n",
-    "        outputs = model(mels, src_key_padding_mask=mel_mask, text_input=texts)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels, src_key_padding_mask=mel_mask, text_input=texts)\n",
     "        if isinstance(outputs, dict):\n",
     "            attn = outputs.get('attn') or outputs.get('attention') or outputs.get('alignments')\n",
     "            if attn is None:\n",
@@ -240,7 +260,7 @@
    "metadata": {},
    "source": [
     "### Diagonal Attention Score\n",
-    "- scores > 0.6\u20130.7 are usually good; trending higher across training is a healthy sign."
+    "- scores > 0.6–0.7 are usually good; trending higher across training is a healthy sign."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -50,7 +50,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({'type': 'CUDA', 'available': False, 'name': 'N/A'})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -84,6 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# import packages and define helper utilities\n",
     "import os\n",
     "import yaml\n",
@@ -202,7 +204,23 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -273,7 +291,9 @@
     "print(f\"Loading model from {model_path}\")\n",
     "\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "print(f'model --> {model_path}')\n",
     "print(f'config --> {config_path}')\n",
@@ -295,8 +315,8 @@
    "metadata": {},
    "source": [
     "## Duration statistics computation\n",
-    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz \u2248 12.5 ms/frame \u2192 8\u201315 frames/phone is typical for EN; tonal languages can vary).\n",
-    "- extremely short (1\u20132 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
+    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz ≈ 12.5 ms/frame → 8–15 frames/phone is typical for EN; tonal languages can vary).\n",
+    "- extremely short (1–2 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
    ]
   },
   {
@@ -346,7 +366,8 @@
     "        mels = mels.to(device)\n",
     "        mel_lens = mel_lens.to(torch.long)\n",
     "\n",
-    "        outputs = model(mels)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get('logits_ctc')\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -50,7 +50,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({\"type\": \"CUDA\", \"available\": False, \"name\": \"N/A\"})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -76,6 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# imports and helper utilities\n",
     "import os\n",
     "import yaml\n",
@@ -195,7 +197,23 @@
     "    return loader\n",
     "\n",
     "NORMALIZATION_MEAN = -4.0\n",
-    "NORMALIZATION_STD = 4.0"
+    "NORMALIZATION_STD = 4.0\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -260,7 +278,9 @@
     "    raise FileNotFoundError(f\"Config file '{config_path}' not found.\")\n",
     "\n",
     "device = torch.device(\"cuda\" if torch.cuda.is_available() else \"cpu\")\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "phoneme_source = config.get(\"phoneme_maps_path\", \"built from dataset\")\n",
     "print(f\"model --> {model_path}\")\n",
@@ -392,7 +412,8 @@
     "        else:\n",
     "            mels_in = mels\n",
     "\n",
-    "        outputs = model(mels_in)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels_in)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get('logits_ctc') or outputs.get('ctc_logits') or outputs.get('primary_logits')\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -50,7 +50,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({'type': 'CUDA', 'available': False, 'name': 'N/A'})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -84,6 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# import packages, define helper utilities\n",
     "import os\n",
     "import yaml\n",
@@ -200,7 +202,23 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -270,7 +288,9 @@
     "model_path = os.path.join(checkpoint_dir, ckpt_files[-1])\n",
     "\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "print(f'model --> {model_path}')\n",
     "print(f'config --> {config_path}')\n",
@@ -376,7 +396,8 @@
     "        text_lens = text_lens.to(torch.long)\n",
     "        mel_lens = mel_lens.to(torch.long)\n",
     "\n",
-    "        outputs = model(mels)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get('logits_ctc') or outputs.get('ctc_logits') or outputs.get('primary_logits')\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -32,7 +32,8 @@
     "        })\n",
     "else:\n",
     "    devices.append({\"type\": \"CUDA\", \"available\": False, \"name\": \"N/A\"})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -66,6 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# import packages and define helper utilities\n",
     "import os\n",
     "import yaml\n",
@@ -187,7 +189,23 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -251,7 +269,9 @@
     "print(f\"Loading model from {model_path}\")\n",
     "\n",
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
-    "model, config, token_map = load_asr_model(model_path, config_path, device)\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
+    "with precision_context():\n",
+    "    model, config, token_map = load_asr_model(model_path, config_path, device)\n",
     "\n",
     "print(f'model --> {model_path}')\n",
     "print(f'config --> {config_path}')\n",
@@ -314,7 +334,8 @@
     "        text_lens = text_lens.to(torch.long)\n",
     "        mel_lens = mel_lens.to(torch.long)\n",
     "\n",
-    "        outputs = model(mels)\n",
+    "        with precision_context():\n",
+    "                outputs = model(mels)\n",
     "        if isinstance(outputs, dict):\n",
     "            logits = outputs.get('logits_ctc')\n",
     "            if logits is None:\n",

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -32,7 +32,8 @@
     "            })\n",
     "else:\n",
     "    devices.append({\"type\": \"CUDA\", \"available\": False, \"name\": \"N/A\"})\n",
-    "devices"
+    "devices\n",
+    "\n"
    ]
   },
   {
@@ -66,6 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from contextlib import nullcontext\n",
     "# import packages, define common functions\n",
     "import torch\n",
     "import yaml\n",
@@ -153,10 +155,27 @@
     "    multi_task_config = cfg_get_nested(config, 'multi_task', {}) or {}\n",
     "    model_params['multi_task_config'] = multi_task_config\n",
     "\n",
-    "    asr_model = _load_model(model_params, ASR_MODEL_PATH)\n",
+    "    with precision_context():\n",
+    "        asr_model = _load_model(model_params, ASR_MODEL_PATH)\n",
     "\n",
     "    return asr_model\n",
-    "\n"
+    "\n",
+    "\n",
+    "\n",
+    "def autocast_context(config: Dict, device: torch.device):\n",
+    "    mp_cfg = cfg_get_nested(config, \"precision.mixed_precision\", {}) or {}\n",
+    "    enabled = bool(mp_cfg.get(\"enabled\", False))\n",
+    "    device_type = device.type if isinstance(device, torch.device) else str(device)\n",
+    "    if not enabled or device_type != \"cuda\" or not torch.cuda.is_available():\n",
+    "        return nullcontext()\n",
+    "    dtype_str = str(mp_cfg.get(\"dtype\", \"float16\")).lower()\n",
+    "    if dtype_str == \"bfloat16\":\n",
+    "        amp_dtype = torch.bfloat16\n",
+    "    else:\n",
+    "        amp_dtype = torch.float16\n",
+    "    return torch.cuda.amp.autocast(device_type=\"cuda\", dtype=amp_dtype)\n",
+    "\n",
+    "precision_context = lambda: nullcontext()\n"
    ]
   },
   {
@@ -234,7 +253,7 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK \u2713\")\n"
+    "print( \"All OK ✓\")\n"
    ]
   },
   {
@@ -248,6 +267,7 @@
    "source": [
     "text_cleaner = TextCleaner(phoneme_map)\n",
     "device = \"cpu\"\n",
+    "precision_context = lambda config=config, device=device: autocast_context(config, device)\n",
     "\n",
     "with open(test_csv_path, \"r\", encoding=\"utf-8\") as f:\n",
     "    test_lines = f.readlines()\n",
@@ -289,7 +309,8 @@
     "        texts, input_lengths, mels, output_lengths = batch  # from Collater\n",
     "\n",
     "        mels = mels.to(device)\n",
-    "        output = model(mels)\n",
+    "        with precision_context():\n",
+    "                output = model(mels)\n",
     "        logits = select_logits_from_output(output)\n",
     "        predicted_ids = torch.argmax(logits, dim=-1)\n",
     "\n",
@@ -428,7 +449,8 @@
     "            batch = next(test_iter)\n",
     "            texts, input_lengths, mels, output_lengths = batch\n",
     "            mels = mels.to(device)\n",
-    "            output = model(mels)\n",
+    "            with precision_context():\n",
+    "                    output = model(mels)\n",
     "            logits = select_logits_from_output(output)\n",
     "            predicted_ids = torch.argmax(logits, dim=-1)\n",
     "\n",
@@ -450,7 +472,7 @@
     "    predictions_cleaned = [' '.join(seq) for seq in predictions]\n",
     "    per = wer(references_cleaned, predictions_cleaned)\n",
     "\n",
-    "    print(f'Phoneme Error Rate: {per:.4f} {\"\u2713\" if per < best_model_per else \"\u2717\"}')\n",
+    "    print(f'Phoneme Error Rate: {per:.4f} {\"✓\" if per < best_model_per else \"✗\"}')\n",
     "    if per < best_model_per:\n",
     "        best_model_per = per\n",
     "        best_model = aux_model_file\n",
@@ -475,7 +497,7 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
    ]
   },
   {

--- a/train.py
+++ b/train.py
@@ -322,6 +322,7 @@ def main(config_path):
         multi_task_config['speaker'] = speaker_cfg
 
     stabilization_config = cfg_get_nested(config, 'stabilization', {}) or {}
+    precision_config = cfg_get_nested(config, 'precision', {}) or {}
 
     model_params = dict(model_params)
     model_params['multi_task_config'] = multi_task_config
@@ -406,6 +407,7 @@ def main(config_path):
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
                     entropy_regularization_config=entropy_regularization_config,
+                    precision_config=precision_config,
                     steps_per_epoch=steps_per_epoch
                     )
 

--- a/trainer.py
+++ b/trainer.py
@@ -637,7 +637,14 @@ class Trainer(object):
     def _autocast_context(self):
         if not self.autocast_enabled or self.device.type != 'cuda':
             return nullcontext()
-        return torch.cuda.amp.autocast(device_type='cuda', dtype=self.autocast_dtype)
+        autocast_kwargs = {}
+        if self.autocast_dtype is not None:
+            autocast_kwargs['dtype'] = self.autocast_dtype
+        try:
+            return torch.cuda.amp.autocast(**autocast_kwargs)
+        except TypeError:
+            # Fallback for PyTorch versions that do not support the dtype argument
+            return torch.cuda.amp.autocast()
 
     def run(self, batch):
         # FIX: trying to fix OOM errors

--- a/trainer.py
+++ b/trainer.py
@@ -5,6 +5,7 @@ import os.path as osp
 import sys
 import time
 from collections import defaultdict
+from contextlib import nullcontext
 
 import numpy as np
 import torch
@@ -51,6 +52,7 @@ class Trainer(object):
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
                  entropy_regularization_config=None,
+                 precision_config=None,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -66,7 +68,10 @@ class Trainer(object):
         self.shuffled_val_dataloader = shuffled_val_dataloader
         self.val_dataloader = sorted_val_dataloader
         self.config = config
-        self.device = device
+        if isinstance(device, torch.device):
+            self.device = device
+        else:
+            self.device = torch.device(device)
         self.finish_train = False
         self.logger = logger
         self.fp16_run = False
@@ -109,6 +114,46 @@ class Trainer(object):
         self.entropy_regularization_eps = float(entropy_cfg.get('eps', 1.0e-6))
         targets_cfg = entropy_cfg.get('targets', {}) if isinstance(entropy_cfg, dict) else {}
         self.entropy_regularization_targets = self._parse_entropy_regularization_targets(targets_cfg, entropy_cfg)
+
+        precision_config = precision_config or {}
+        mixed_precision_cfg = precision_config.get('mixed_precision', {}) if isinstance(precision_config, dict) else {}
+        self.autocast_enabled = False
+        self.autocast_dtype = None
+        self.grad_scaler = None
+
+        if (
+            isinstance(mixed_precision_cfg, dict)
+            and bool(mixed_precision_cfg.get('enabled', False))
+            and self.device.type == 'cuda'
+            and torch.cuda.is_available()
+        ):
+            dtype_str = str(mixed_precision_cfg.get('dtype', 'float16')).lower()
+            if dtype_str == 'bfloat16':
+                self.autocast_dtype = torch.bfloat16
+            else:
+                self.autocast_dtype = torch.float16
+
+            scaler_cfg = mixed_precision_cfg.get('grad_scaler') or mixed_precision_cfg.get('scaler') or {}
+            scaler_kwargs = {}
+            if isinstance(scaler_cfg, dict):
+                if 'init_scale' in scaler_cfg:
+                    scaler_kwargs['init_scale'] = float(scaler_cfg['init_scale'])
+                if 'growth_factor' in scaler_cfg:
+                    scaler_kwargs['growth_factor'] = float(scaler_cfg['growth_factor'])
+                if 'backoff_factor' in scaler_cfg:
+                    scaler_kwargs['backoff_factor'] = float(scaler_cfg['backoff_factor'])
+                if 'growth_interval' in scaler_cfg:
+                    scaler_kwargs['growth_interval'] = int(scaler_cfg['growth_interval'])
+                scaler_enabled = bool(scaler_cfg.get('enabled', True))
+            else:
+                scaler_enabled = True
+
+            self.grad_scaler = torch.cuda.amp.GradScaler(
+                enabled=scaler_enabled,
+                **scaler_kwargs,
+            )
+            self.autocast_enabled = True
+            self.fp16_run = True
 
         self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
@@ -353,6 +398,8 @@ class Trainer(object):
             "epochs": self.epochs,
         }
         state_dict["model"] = self.model.state_dict()
+        if self.grad_scaler is not None:
+            state_dict["grad_scaler"] = self.grad_scaler.state_dict()
 
         if not os.path.exists(os.path.dirname(checkpoint_path)):
             os.makedirs(os.path.dirname(checkpoint_path))
@@ -379,6 +426,9 @@ class Trainer(object):
             # overwrite schedular argument parameters
             state_dict["scheduler"].update(**self.config.get("scheduler_params", {}))
             self.scheduler.load_state_dict(state_dict["scheduler"])
+
+            if self.grad_scaler is not None and "grad_scaler" in state_dict:
+                self.grad_scaler.load_state_dict(state_dict["grad_scaler"])
 
         if not load_only_params:
             self._resumed_from_checkpoint = True
@@ -552,7 +602,7 @@ class Trainer(object):
 
     def _compute_ctc_loss(self, logits, targets, input_lengths, target_lengths, mix_metadata=None):
         ctc = self.criterion['ctc']
-        log_probs = logits.log_softmax(dim=2).transpose(0, 1)
+        log_probs = logits.float().log_softmax(dim=2).transpose(0, 1)
         primary_loss = ctc(log_probs, targets, input_lengths, target_lengths)
         if primary_loss.dim() == 0:
             primary_loss = primary_loss.unsqueeze(0)
@@ -584,10 +634,15 @@ class Trainer(object):
 
         return total_loss.mean()
 
+    def _autocast_context(self):
+        if not self.autocast_enabled or self.device.type != 'cuda':
+            return nullcontext()
+        return torch.cuda.amp.autocast(device_type='cuda', dtype=self.autocast_dtype)
+
     def run(self, batch):
         # FIX: trying to fix OOM errors
         #torch.cuda.empty_cache()
-        self.optimizer.zero_grad()
+        self.optimizer.zero_grad(set_to_none=True)
         processed_batch = []
         for element in batch:
             if hasattr(element, 'to'):
@@ -612,8 +667,9 @@ class Trainer(object):
             mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
         mel_mask = self.model.length_to_mask(mel_input_length)
         text_mask = self.model.length_to_mask(text_input_length)
-        model_outputs = self.model(
-            mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+        with self._autocast_context():
+            model_outputs = self.model(
+                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
         losses = {}
         if mix_metadata:
@@ -766,15 +822,22 @@ class Trainer(object):
             losses['diag_attn'] = loss_diagonal.item()
         
         loss = total_loss
-        loss.backward()
-        torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
-        self.optimizer.step()
+        if self.grad_scaler is not None:
+            self.grad_scaler.scale(loss).backward()
+            self.grad_scaler.unscale_(self.optimizer)
+            torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
+            self.grad_scaler.step(self.optimizer)
+            self.grad_scaler.update()
+        else:
+            loss.backward()
+            torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
+            self.optimizer.step()
         self.scheduler.step()
-        losses['loss'] = loss.item()
+        losses['loss'] = float(loss.detach().item())
         if 'ctc' not in losses:
-            losses['ctc'] = loss_ctc.item()
+            losses['ctc'] = float(loss_ctc.detach().item())
         if 's2s' not in losses:
-            losses['s2s'] = loss_s2s.item()
+            losses['s2s'] = float(loss_s2s.detach().item())
         return losses
 
     def _train_epoch(self):
@@ -834,8 +897,9 @@ class Trainer(object):
                 mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
             mel_mask = self.model.length_to_mask(mel_input_length)
             text_mask = self.model.length_to_mask(text_input_length)
-            model_outputs = self.model(
-                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+            with self._autocast_context():
+                model_outputs = self.model(
+                    mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
             ppgs = model_outputs.get('ctc_logits')
             s2s_pred = model_outputs.get('s2s_logits')
@@ -849,7 +913,7 @@ class Trainer(object):
                     text_input_length,
                     mix_metadata=None,
                 )
-                eval_losses["eval/ctc"].append(loss_ctc.item())
+                eval_losses["eval/ctc"].append(float(loss_ctc.detach().item()))
             else:
                 loss_ctc = torch.zeros(1, device=self.device)
 
@@ -858,7 +922,7 @@ class Trainer(object):
                 for _s2s_pred, _text_input, _text_length in zip(s2s_pred, text_input, text_input_length):
                     loss_s2s += self.criterion['ce'](_s2s_pred[:_text_length], _text_input[:_text_length])
                 loss_s2s /= max(1, text_input.size(0))
-                eval_losses["eval/s2s"].append(loss_s2s.item())
+                eval_losses["eval/s2s"].append(float(loss_s2s.detach().item()))
             else:
                 loss_s2s = torch.zeros(1, device=self.device)
 
@@ -873,12 +937,12 @@ class Trainer(object):
                     entropy_ctc = self._compute_entropy_regularization(ppgs, lengths=mel_input_length, key='ctc')
                     if entropy_ctc is not None:
                         total_eval_loss = total_eval_loss + entropy_ctc
-                        eval_losses['eval/entropy_ctc'].append(entropy_ctc.item())
+                        eval_losses['eval/entropy_ctc'].append(float(entropy_ctc.detach().item()))
                 if s2s_pred is not None:
                     entropy_s2s = self._compute_entropy_regularization(s2s_pred, lengths=text_input_length, key='s2s')
                     if entropy_s2s is not None:
                         total_eval_loss = total_eval_loss + entropy_s2s
-                        eval_losses['eval/entropy_s2s'].append(entropy_s2s.item())
+                        eval_losses['eval/entropy_s2s'].append(float(entropy_s2s.detach().item()))
 
             intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
             if (
@@ -900,10 +964,10 @@ class Trainer(object):
                     )
                     weight = float(self.intermediate_ctc_layer_weights.get(str(layer_key), 1.0))
                     layer_losses = layer_losses + weight * layer_loss
-                    eval_losses[f'eval/intermediate_ctc/layer_{layer_key}'].append(layer_loss.item())
+                    eval_losses[f'eval/intermediate_ctc/layer_{layer_key}'].append(float(layer_loss.detach().item()))
 
                 total_eval_loss = total_eval_loss + self.intermediate_ctc_weight * layer_losses
-                eval_losses['eval/intermediate_ctc'].append(layer_losses.item())
+                eval_losses['eval/intermediate_ctc'].append(float(layer_losses.detach().item()))
 
             self_conditioned_outputs = model_outputs.get('self_conditioned_ctc_logits') or {}
             if (
@@ -925,10 +989,10 @@ class Trainer(object):
                     )
                     weight = float(self.self_conditioned_ctc_layer_weights.get(str(layer_key), 1.0))
                     sc_losses = sc_losses + weight * sc_loss
-                    eval_losses[f'eval/self_conditioned_ctc/layer_{layer_key}'].append(sc_loss.item())
+                    eval_losses[f'eval/self_conditioned_ctc/layer_{layer_key}'].append(float(sc_loss.detach().item()))
 
                 total_eval_loss = total_eval_loss + self.self_conditioned_ctc_weight * sc_losses
-                eval_losses['eval/self_conditioned_ctc'].append(sc_losses.item())
+                eval_losses['eval/self_conditioned_ctc'].append(float(sc_losses.detach().item()))
 
             if self.enable_frame_classifier and self.frame_weight > 0:
                 frame_logits = model_outputs.get('frame_phoneme_logits')
@@ -937,7 +1001,7 @@ class Trainer(object):
                     frame_loss = self.criterion['frame_ce'](frame_logits.reshape(-1, frame_logits.size(2)),
                                                             frame_targets.view(-1))
                     total_eval_loss = total_eval_loss + self.frame_weight * frame_loss
-                    eval_losses['eval/frame_phoneme'].append(frame_loss.item())
+                    eval_losses['eval/frame_phoneme'].append(float(frame_loss.detach().item()))
 
             if self.enable_speaker and self.speaker_weight > 0:
                 speaker_logits = model_outputs.get('speaker_logits')


### PR DESCRIPTION
## Summary
- add configurable mixed-precision training support in the trainer using autocast and GradScaler, with checkpoint persistence
- expose precision options in the main training config and plumb them through the training entrypoint
- refresh utility notebooks to define a shared autocast helper and wrap model calls with the configured precision context

## Testing
- python -m compileall trainer.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d7a4a60aa483329fda901c4c58f859