### PR TITLE
Add configurable lazy mask creation and update notebooks

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -10,6 +10,12 @@ val_data: "Data/val_list.txt"
 ood_data: "Data/OOD_texts.txt"
 phoneme_maps_path: "Data/word_index_dict.txt"
 
+memory_optimizations:
+  lazy_masks:
+    enabled: true
+    future_mask: true
+    text_mask: true
+
 preprocess_params:
   sr: 24000
   spect_params:

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f6a411ce",
    "metadata": {},
    "source": [
@@ -204,7 +211,14 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -288,7 +302,14 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')"
+    "print(f'Blank token id: {BLANK_ID}')",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0993ecfa",
    "metadata": {},
    "source": [
@@ -205,7 +212,14 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -281,7 +295,14 @@
     "if \" \" not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = int(token_map[\" \"])\n",
-    "print(f\"Blank token id: {BLANK_ID}\")\n"
+    "print(f\"Blank token id: {BLANK_ID}\")\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "225c5b82",
    "metadata": {},
    "source": [
@@ -142,7 +149,14 @@
     "\n",
     "dev_loader, val_entries = build_dev_dataloader_from_config(config, device)\n",
     "print(f'Validation dataset size: {len(val_entries)} samples')\n",
-    "print(f'Batch size --> {dev_loader.batch_size}')\n"
+    "print(f'Batch size --> {dev_loader.batch_size}')\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "intro-duration",
    "metadata": {},
    "source": [
@@ -202,7 +209,14 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -286,7 +300,14 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')\n"
+    "print(f'Blank token id: {BLANK_ID}')\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b57e77d8",
    "metadata": {},
    "source": [
@@ -195,7 +202,14 @@
     "    return loader\n",
     "\n",
     "NORMALIZATION_MEAN = -4.0\n",
-    "NORMALIZATION_STD = 4.0"
+    "NORMALIZATION_STD = 4.0",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -287,7 +301,14 @@
     "    if decoder.cold_fusion_lm is not None:\n",
     "        fusion_flags.append('cold fusion LM')\n",
     "    fusion_desc = ' with ' + ' and '.join(fusion_flags) if fusion_flags else ''\n",
-    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n"
+    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -13,6 +13,13 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f245669c",
    "metadata": {},
    "source": [
@@ -200,7 +207,14 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader\n"
+    "    return loader\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -298,7 +312,14 @@
     "    if decoder.cold_fusion_lm is not None:\n",
     "        fusion_flags.append('cold fusion LM')\n",
     "    fusion_desc = ' with ' + ' and '.join(fusion_flags) if fusion_flags else ''\n",
-    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n"
+    "    print(f'Decoding strategy: Beam search (beam={decoder.beam_width}){fusion_desc}')\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "0b812a58",
@@ -187,7 +194,14 @@
     "        collate_config=collate_config,\n",
     "        dataset_config=dataset_params,\n",
     "    )\n",
-    "    return loader"
+    "    return loader",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -264,7 +278,14 @@
     "if ' ' not in token_map:\n",
     "    raise KeyError(\"The vocabulary does not contain the blank symbol ' '.\")\n",
     "BLANK_ID = token_map[' ']\n",
-    "print(f'Blank token id: {BLANK_ID}')"
+    "print(f'Blank token id: {BLANK_ID}')",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -12,6 +12,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "48c765c9-c6ea-4a1a-b653-22514b84e3e2",
@@ -156,7 +163,14 @@
     "    asr_model = _load_model(model_params, ASR_MODEL_PATH)\n",
     "\n",
     "    return asr_model\n",
-    "\n"
+    "\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -234,7 +248,14 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK \u2713\")\n"
+    "print( \"All OK \u2713\")\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {
@@ -475,7 +496,14 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n"
+    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n",
+    "\n",
+    "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
+    "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
+    "lazy_enabled = bool(lazy_mask_cfg.get(\"enabled\", True))\n",
+    "print(f\"lazy mask creation enabled --> {lazy_enabled}\")\n",
+    "print(f\"skip future mask allocation --> {bool(lazy_mask_cfg.get('future_mask', True))}\")\n",
+    "print(f\"skip text mask allocation --> {bool(lazy_mask_cfg.get('text_mask', True))}\")\n"
    ]
   },
   {

--- a/train.py
+++ b/train.py
@@ -322,6 +322,7 @@ def main(config_path):
         multi_task_config['speaker'] = speaker_cfg
 
     stabilization_config = cfg_get_nested(config, 'stabilization', {}) or {}
+    memory_optimization_config = cfg_get_nested(config, 'memory_optimizations', {}) or {}
 
     model_params = dict(model_params)
     model_params['multi_task_config'] = multi_task_config
@@ -406,6 +407,7 @@ def main(config_path):
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
                     entropy_regularization_config=entropy_regularization_config,
+                    memory_optimization_config=memory_optimization_config,
                     steps_per_epoch=steps_per_epoch
                     )
 

--- a/trainer.py
+++ b/trainer.py
@@ -51,6 +51,7 @@ class Trainer(object):
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
                  entropy_regularization_config=None,
+                 memory_optimization_config=None,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -109,6 +110,16 @@ class Trainer(object):
         self.entropy_regularization_eps = float(entropy_cfg.get('eps', 1.0e-6))
         targets_cfg = entropy_cfg.get('targets', {}) if isinstance(entropy_cfg, dict) else {}
         self.entropy_regularization_targets = self._parse_entropy_regularization_targets(targets_cfg, entropy_cfg)
+
+        memopt_cfg = memory_optimization_config or {}
+        if not isinstance(memopt_cfg, dict):
+            memopt_cfg = {}
+        lazy_masks_cfg = memopt_cfg.get('lazy_masks', {}) or {}
+        if not isinstance(lazy_masks_cfg, dict):
+            lazy_masks_cfg = {}
+        lazy_enabled = bool(lazy_masks_cfg.get('enabled', True))
+        self.skip_future_mask_allocation = lazy_enabled and bool(lazy_masks_cfg.get('future_mask', True))
+        self.skip_text_mask_allocation = lazy_enabled and bool(lazy_masks_cfg.get('text_mask', True))
 
         self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
@@ -191,6 +202,23 @@ class Trainer(object):
         if weight == 0.0:
             return None
         return cfg
+
+    def _maybe_create_future_mask(self, length: int):
+        if self.skip_future_mask_allocation:
+            return None
+        if length is None or length <= 0:
+            return None
+        mask = self.model.get_future_mask(length, unmask_future_steps=0)
+        if mask is None:
+            return None
+        return mask.to(self.device) if hasattr(mask, 'to') else mask
+
+    def _maybe_create_text_mask(self, lengths):
+        if self.skip_text_mask_allocation:
+            return None
+        if lengths is None:
+            return None
+        return self.model.length_to_mask(lengths)
 
     def _compute_entropy_regularization(self, logits, lengths=None, key='ctc'):
         cfg = self._entropy_target_config(key)
@@ -608,10 +636,11 @@ class Trainer(object):
             mel_input, mix_metadata = self._apply_mixspeech(mel_input)
 
         mel_input_length = mel_input_length // (2 ** self.model.n_down)
-        future_mask = self.model.get_future_mask(
-            mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
+        future_mask = self._maybe_create_future_mask(
+            mel_input.size(2) // (2 ** self.model.n_down)
+        )
         mel_mask = self.model.length_to_mask(mel_input_length)
-        text_mask = self.model.length_to_mask(text_input_length)
+        text_mask = self._maybe_create_text_mask(text_input_length)
         model_outputs = self.model(
             mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
@@ -830,10 +859,11 @@ class Trainer(object):
             else:
                 speaker_ids = torch.zeros(text_input.size(0), device=self.device, dtype=torch.long)
             mel_input_length = mel_input_length // (2 ** self.model.n_down)
-            future_mask = self.model.get_future_mask(
-                mel_input.size(2)//(2**self.model.n_down), unmask_future_steps=0).to(self.device)
+            future_mask = self._maybe_create_future_mask(
+                mel_input.size(2) // (2 ** self.model.n_down)
+            )
             mel_mask = self.model.length_to_mask(mel_input_length)
-            text_mask = self.model.length_to_mask(text_input_length)
+            text_mask = self._maybe_create_text_mask(text_input_length)
             model_outputs = self.model(
                 mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 


### PR DESCRIPTION
## Summary
- add `memory_optimizations.lazy_masks` options to the configuration and propagate them through the training entrypoint
- lazily allocate decoder masks inside the trainer to avoid unused `future_mask` and `text_mask` tensors unless explicitly requested
- refresh the utility notebooks with documentation and runtime checks for the new lazy mask controls

## Testing
- python -m compileall trainer.py train.py models.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b3c7119883329d71bb3bdad5b873