### PR TITLE
Add configurable mixed precision training support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -10,6 +10,17 @@ val_data: "Data/val_list.txt"
 ood_data: "Data/OOD_texts.txt"
 phoneme_maps_path: "Data/word_index_dict.txt"
 
+training:
+  mixed_precision:
+    enabled: false
+    dtype: float16
+    grad_scaler:
+      enabled: true
+      init_scale: 65536.0
+      growth_factor: 2.0
+      backoff_factor: 0.5
+      growth_interval: 2000
+
 memory_optimizations:
   lazy_masks:
     enabled: true

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {
@@ -320,7 +321,7 @@
     "## CTC entropy statistics\n",
     "- mean_maxprob often ends up > 0.6;\n",
     "- mean_entropy should drop well below log(V);\n",
-    "- mean_blank_rate typically sits around 0.6\u20130.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
+    "- mean_blank_rate typically sits around 0.6–0.8 for good CTCs (too high can indicate over-blanking; too low can indicate smeared posteriors)."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {
@@ -311,7 +312,7 @@
    "metadata": {},
    "source": [
     "## Mean CTC loss evaluation\n",
-    "- simple early-stopping signal; shouldn\u2019t diverge vs train."
+    "- simple early-stopping signal; shouldn’t diverge vs train."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {
@@ -254,7 +255,7 @@
    "metadata": {},
    "source": [
     "### Diagonal Attention Score\n",
-    "- scores > 0.6\u20130.7 are usually good; trending higher across training is a healthy sign."
+    "- scores > 0.6–0.7 are usually good; trending higher across training is a healthy sign."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {
@@ -316,8 +317,8 @@
    "metadata": {},
    "source": [
     "## Duration statistics computation\n",
-    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz \u2248 12.5 ms/frame \u2192 8\u201315 frames/phone is typical for EN; tonal languages can vary).\n",
-    "- extremely short (1\u20132 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
+    "- frames_per_token_mean should be consistent with your hop size and speaking rate (e.g., hop 300 @ 24 kHz ≈ 12.5 ms/frame → 8–15 frames/phone is typical for EN; tonal languages can vary).\n",
+    "- extremely short (1–2 frame) phones dominating or huge tails (>200 frames) often indicate alignment issues."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -8,7 +8,8 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "* Mixed-precision training can be toggled via the `training.mixed_precision` section in `Configs/config.yml`, which enables autocast and the GradScaler during training runs launched from this notebook.\n"
    ]
   },
   {
@@ -248,7 +249,7 @@
     "model = load_ASR_models(model_path, config_path)\n",
     "model.eval()\n",
     "\n",
-    "print( \"All OK \u2713\")\n",
+    "print( \"All OK ✓\")\n",
     "\n",
     "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
     "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",
@@ -471,7 +472,7 @@
     "    predictions_cleaned = [' '.join(seq) for seq in predictions]\n",
     "    per = wer(references_cleaned, predictions_cleaned)\n",
     "\n",
-    "    print(f'Phoneme Error Rate: {per:.4f} {\"\u2713\" if per < best_model_per else \"\u2717\"}')\n",
+    "    print(f'Phoneme Error Rate: {per:.4f} {\"✓\" if per < best_model_per else \"✗\"}')\n",
     "    if per < best_model_per:\n",
     "        best_model_per = per\n",
     "        best_model = aux_model_file\n",
@@ -496,7 +497,7 @@
     "    print(\"------------------------\")\n",
     "\n",
     "best = results_sorted[0]\n",
-    "print(f\"\u2705 Best model: {best['model']} with PER = {best['per']:.4f}\")\n",
+    "print(f\"✅ Best model: {best['model']} with PER = {best['per']:.4f}\")\n",
     "\n",
     "memory_opts = config.get(\"memory_optimizations\", {}) if isinstance(config, dict) else {}\n",
     "lazy_mask_cfg = memory_opts.get(\"lazy_masks\", {}) if isinstance(memory_opts, dict) else {}\n",

--- a/train.py
+++ b/train.py
@@ -378,6 +378,7 @@ def main(config_path):
     if isinstance(self_conditioned_ctc_config, dict) and 'loss_weight' not in self_conditioned_ctc_config:
         self_conditioned_ctc_config = dict(self_conditioned_ctc_config)
         self_conditioned_ctc_config['loss_weight'] = float(loss_weight_config.get('self_conditioned_ctc', 0.0))
+    training_config = cfg_get_nested(config, 'training', {}) or {}
 
     steps_per_epoch = len(sorted_train_dataloader) if sorted_train_dataloader is not None else len(shuffled_train_dataloader)
 
@@ -407,6 +408,7 @@ def main(config_path):
                     intermediate_ctc_config=intermediate_ctc_config,
                     self_conditioned_ctc_config=self_conditioned_ctc_config,
                     entropy_regularization_config=entropy_regularization_config,
+                    mixed_precision_config=training_config.get('mixed_precision', {}),
                     memory_optimization_config=memory_optimization_config,
                     steps_per_epoch=steps_per_epoch
                     )

--- a/trainer.py
+++ b/trainer.py
@@ -11,6 +11,7 @@ import torch
 from torch import nn
 from PIL import Image
 from tqdm import tqdm
+from contextlib import nullcontext
 
 from utils import calc_wer
 
@@ -51,6 +52,7 @@ class Trainer(object):
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
                  entropy_regularization_config=None,
+                 mixed_precision_config=None,
                  memory_optimization_config=None,
                  steps_per_epoch=None):
 
@@ -70,7 +72,6 @@ class Trainer(object):
         self.device = device
         self.finish_train = False
         self.logger = logger
-        self.fp16_run = False
         self.switch_sortagrad_dataset_epoch = switch_sortagrad_dataset_epoch
         self.use_diagonal_attention_prior = use_diagonal_attention_prior
         self.diagonal_attention_prior_weight = diagonal_attention_prior_weight
@@ -84,6 +85,49 @@ class Trainer(object):
         self.enable_frame_classifier = enable_frame_classifier
         self.enable_speaker = enable_speaker
         self.enable_pronunciation_error = enable_pronunciation_error
+
+        mp_cfg = mixed_precision_config or {}
+        if not isinstance(mp_cfg, dict):
+            mp_cfg = {}
+        dtype_str = str(mp_cfg.get('dtype', 'float16')).lower()
+        dtype_map = {
+            'float16': torch.float16,
+            'fp16': torch.float16,
+            'half': torch.float16,
+            'bfloat16': torch.bfloat16,
+            'bf16': torch.bfloat16,
+            'float32': torch.float32,
+            'fp32': torch.float32,
+        }
+        self.autocast_dtype = dtype_map.get(dtype_str, torch.float16)
+        requested_amp = bool(mp_cfg.get('enabled', False))
+        device_type = getattr(self.device, 'type', 'cpu') if self.device is not None else 'cpu'
+        self.amp_enabled = bool(requested_amp and device_type == 'cuda' and torch.cuda.is_available())
+        if requested_amp and not self.amp_enabled and self.logger:
+            self.logger.info(
+                "[AMP]: mixed precision requested but CUDA device was not available; running in full precision."
+            )
+
+        grad_scaler_cfg = mp_cfg.get('grad_scaler', {}) or {}
+        if not isinstance(grad_scaler_cfg, dict):
+            grad_scaler_cfg = {}
+        requested_scaler = bool(grad_scaler_cfg.get('enabled', True))
+        self.grad_scaler_enabled = bool(
+            self.amp_enabled and self.autocast_dtype == torch.float16 and requested_scaler
+        )
+        self.grad_scaler = None
+        if self.grad_scaler_enabled:
+            scaler_kwargs = {}
+            for key in ('init_scale', 'growth_factor', 'backoff_factor', 'growth_interval', 'hysteresis'):
+                if key in grad_scaler_cfg:
+                    scaler_kwargs[key] = grad_scaler_cfg[key]
+            self.grad_scaler = torch.cuda.amp.GradScaler(**scaler_kwargs)
+
+        self._autocast_kwargs = {}
+        if self.amp_enabled:
+            self._autocast_kwargs['dtype'] = self.autocast_dtype
+
+        self.fp16_run = bool(self.amp_enabled and self.autocast_dtype == torch.float16)
 
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
@@ -191,6 +235,11 @@ class Trainer(object):
                 'reduction': str(cfg.get('reduction', 'mean')).lower(),
             }
         return parsed
+
+    def _autocast_context(self):
+        if self.amp_enabled:
+            return torch.cuda.amp.autocast(**self._autocast_kwargs)
+        return nullcontext()
 
     def _entropy_target_config(self, key):
         if not self.entropy_regularization_enabled:
@@ -580,7 +629,7 @@ class Trainer(object):
 
     def _compute_ctc_loss(self, logits, targets, input_lengths, target_lengths, mix_metadata=None):
         ctc = self.criterion['ctc']
-        log_probs = logits.log_softmax(dim=2).transpose(0, 1)
+        log_probs = logits.float().log_softmax(dim=2).transpose(0, 1)
         primary_loss = ctc(log_probs, targets, input_lengths, target_lengths)
         if primary_loss.dim() == 0:
             primary_loss = primary_loss.unsqueeze(0)
@@ -615,7 +664,7 @@ class Trainer(object):
     def run(self, batch):
         # FIX: trying to fix OOM errors
         #torch.cuda.empty_cache()
-        self.optimizer.zero_grad()
+        self.optimizer.zero_grad(set_to_none=True)
         processed_batch = []
         for element in batch:
             if hasattr(element, 'to'):
@@ -641,164 +690,181 @@ class Trainer(object):
         )
         mel_mask = self.model.length_to_mask(mel_input_length)
         text_mask = self._maybe_create_text_mask(text_input_length)
-        model_outputs = self.model(
-            mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
-
         losses = {}
-        if mix_metadata:
-            losses['mixspeech/avg_lambda'] = mix_metadata['avg_lambda']
-            active_ratio = (mix_metadata['secondary_indices'] >= 0).float().mean().item()
-            losses['mixspeech/applicable_ratio'] = active_ratio
-        total_loss = torch.zeros(1, device=self.device)
 
-        ppgs = model_outputs.get('ctc_logits')
-        if self.ctc_weight > 0 and ppgs is not None:
-            loss_ctc = self._compute_ctc_loss(ppgs, text_input, mel_input_length, text_input_length, mix_metadata)
-            total_loss = total_loss + self.ctc_weight * loss_ctc
-            losses['ctc'] = loss_ctc.item()
-        else:
-            loss_ctc = torch.zeros(1, device=self.device)
+        with self._autocast_context():
+            model_outputs = self.model(
+                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
-        s2s_pred = model_outputs.get('s2s_logits')
-        s2s_attn = model_outputs.get('s2s_attn')
-        if self.s2s_weight > 0 and s2s_pred is not None:
-            loss_s2s = torch.zeros(1, device=self.device)
-            total_samples = text_input.size(0)
-            lam_primary = mix_metadata['lam_primary'] if mix_metadata else None
-            lam_secondary = mix_metadata['lam_secondary'] if mix_metadata else None
-            secondary_indices = mix_metadata['secondary_indices'] if mix_metadata else None
-            fallback_indices = torch.arange(total_samples, device=self.device, dtype=torch.long)
+            if mix_metadata:
+                losses['mixspeech/avg_lambda'] = mix_metadata['avg_lambda']
+                active_ratio = (mix_metadata['secondary_indices'] >= 0).float().mean().item()
+                losses['mixspeech/applicable_ratio'] = active_ratio
+            total_loss = torch.zeros(1, device=self.device)
 
-            for idx, (_s2s_pred, _text_input, _text_length) in enumerate(zip(s2s_pred, text_input, text_input_length)):
-                main_len = int(_text_length.item())
-                main_len = min(main_len, _s2s_pred.size(0))
-                if main_len <= 0:
-                    continue
-                ce_loss = self.criterion['ce'](_s2s_pred[:main_len], _text_input[:main_len])
-                weight_primary = lam_primary[idx] if lam_primary is not None else 1.0
-                sample_loss = ce_loss * weight_primary
+            ppgs = model_outputs.get('ctc_logits')
+            if self.ctc_weight > 0 and ppgs is not None:
+                loss_ctc = self._compute_ctc_loss(ppgs, text_input, mel_input_length, text_input_length, mix_metadata)
+                total_loss = total_loss + self.ctc_weight * loss_ctc
+                losses['ctc'] = loss_ctc.item()
+            else:
+                loss_ctc = torch.zeros(1, device=self.device)
 
-                if lam_secondary is not None and lam_secondary[idx] > 0:
-                    partner_idx = secondary_indices[idx] if secondary_indices[idx] >= 0 else fallback_indices[idx]
-                    partner_idx = int(partner_idx.item())
-                    partner_len = int(text_input_length[partner_idx].item())
-                    partner_len = min(partner_len, _s2s_pred.size(0))
-                    if partner_len > 0:
-                        partner_target = text_input[partner_idx, :partner_len]
-                        ce_partner = self.criterion['ce'](_s2s_pred[:partner_len], partner_target)
-                        sample_loss = sample_loss + ce_partner * lam_secondary[idx]
+            s2s_pred = model_outputs.get('s2s_logits')
+            s2s_attn = model_outputs.get('s2s_attn')
+            if self.s2s_weight > 0 and s2s_pred is not None:
+                loss_s2s = torch.zeros(1, device=self.device)
+                total_samples = text_input.size(0)
+                lam_primary = mix_metadata['lam_primary'] if mix_metadata else None
+                lam_secondary = mix_metadata['lam_secondary'] if mix_metadata else None
+                secondary_indices = mix_metadata['secondary_indices'] if mix_metadata else None
+                fallback_indices = torch.arange(total_samples, device=self.device, dtype=torch.long)
 
-                loss_s2s = loss_s2s + sample_loss
+                for idx, (_s2s_pred, _text_input, _text_length) in enumerate(zip(s2s_pred, text_input, text_input_length)):
+                    main_len = int(_text_length.item())
+                    main_len = min(main_len, _s2s_pred.size(0))
+                    if main_len <= 0:
+                        continue
+                    ce_loss = self.criterion['ce'](_s2s_pred[:main_len], _text_input[:main_len])
+                    weight_primary = lam_primary[idx] if lam_primary is not None else 1.0
+                    sample_loss = ce_loss * weight_primary
 
-            loss_s2s = loss_s2s / max(1, text_input.size(0))
-            total_loss = total_loss + self.s2s_weight * loss_s2s
-            losses['s2s'] = loss_s2s.item()
-        else:
-            loss_s2s = torch.zeros(1, device=self.device)
+                    if lam_secondary is not None and lam_secondary[idx] > 0:
+                        partner_idx = secondary_indices[idx] if secondary_indices[idx] >= 0 else fallback_indices[idx]
+                        partner_idx = int(partner_idx.item())
+                        partner_len = int(text_input_length[partner_idx].item())
+                        partner_len = min(partner_len, _s2s_pred.size(0))
+                        if partner_len > 0:
+                            partner_target = text_input[partner_idx, :partner_len]
+                            ce_partner = self.criterion['ce'](_s2s_pred[:partner_len], partner_target)
+                            sample_loss = sample_loss + ce_partner * lam_secondary[idx]
 
-        if self.entropy_regularization_enabled:
-            if ppgs is not None:
-                entropy_ctc = self._compute_entropy_regularization(ppgs, lengths=mel_input_length, key='ctc')
-                if entropy_ctc is not None:
-                    total_loss = total_loss + entropy_ctc
-                    losses['entropy/ctc'] = entropy_ctc.item() if torch.is_tensor(entropy_ctc) else float(entropy_ctc)
-            if s2s_pred is not None:
-                entropy_s2s = self._compute_entropy_regularization(s2s_pred, lengths=text_input_length, key='s2s')
-                if entropy_s2s is not None:
-                    total_loss = total_loss + entropy_s2s
-                    losses['entropy/s2s'] = entropy_s2s.item() if torch.is_tensor(entropy_s2s) else float(entropy_s2s)
+                    loss_s2s = loss_s2s + sample_loss
 
-        intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
-        if (
-            self.intermediate_ctc_enabled
-            and self.intermediate_ctc_weight > 0.0
-            and isinstance(intermediate_outputs, dict)
-            and intermediate_outputs
-        ):
-            layer_losses = torch.zeros(1, device=self.device)
-            for layer_key, logits in intermediate_outputs.items():
-                if not isinstance(logits, torch.Tensor):
-                    continue
-                layer_loss = self._compute_ctc_loss(logits, text_input, mel_input_length, text_input_length, mix_metadata)
-                weight = float(self.intermediate_ctc_layer_weights.get(str(layer_key), 1.0))
-                layer_losses = layer_losses + weight * layer_loss
-                losses[f'intermediate_ctc/layer_{layer_key}'] = layer_loss.item()
+                loss_s2s = loss_s2s / max(1, text_input.size(0))
+                total_loss = total_loss + self.s2s_weight * loss_s2s
+                losses['s2s'] = loss_s2s.item()
+            else:
+                loss_s2s = torch.zeros(1, device=self.device)
 
-            total_loss = total_loss + self.intermediate_ctc_weight * layer_losses
-            losses['intermediate_ctc'] = layer_losses.item()
+            if self.entropy_regularization_enabled:
+                if ppgs is not None:
+                    entropy_ctc = self._compute_entropy_regularization(ppgs, lengths=mel_input_length, key='ctc')
+                    if entropy_ctc is not None:
+                        total_loss = total_loss + entropy_ctc
+                        losses['entropy/ctc'] = entropy_ctc.item() if torch.is_tensor(entropy_ctc) else float(entropy_ctc)
+                if s2s_pred is not None:
+                    entropy_s2s = self._compute_entropy_regularization(s2s_pred, lengths=text_input_length, key='s2s')
+                    if entropy_s2s is not None:
+                        total_loss = total_loss + entropy_s2s
+                        losses['entropy/s2s'] = entropy_s2s.item() if torch.is_tensor(entropy_s2s) else float(entropy_s2s)
 
-        self_conditioned_outputs = model_outputs.get('self_conditioned_ctc_logits') or {}
-        if (
-            self.self_conditioned_ctc_enabled
-            and self.self_conditioned_ctc_weight > 0.0
-            and isinstance(self_conditioned_outputs, dict)
-            and self_conditioned_outputs
-        ):
-            sc_losses = torch.zeros(1, device=self.device)
-            for layer_key, logits in self_conditioned_outputs.items():
-                if not isinstance(logits, torch.Tensor):
-                    continue
-                sc_loss = self._compute_ctc_loss(logits, text_input, mel_input_length, text_input_length, mix_metadata)
-                weight = float(self.self_conditioned_ctc_layer_weights.get(str(layer_key), 1.0))
-                sc_losses = sc_losses + weight * sc_loss
-                losses[f'self_conditioned_ctc/layer_{layer_key}'] = sc_loss.item()
+            intermediate_outputs = model_outputs.get('intermediate_ctc_logits') or {}
+            if (
+                self.intermediate_ctc_enabled
+                and self.intermediate_ctc_weight > 0.0
+                and isinstance(intermediate_outputs, dict)
+                and intermediate_outputs
+            ):
+                layer_losses = torch.zeros(1, device=self.device)
+                for layer_key, logits in intermediate_outputs.items():
+                    if not isinstance(logits, torch.Tensor):
+                        continue
+                    layer_loss = self._compute_ctc_loss(logits, text_input, mel_input_length, text_input_length, mix_metadata)
+                    weight = float(self.intermediate_ctc_layer_weights.get(str(layer_key), 1.0))
+                    layer_losses = layer_losses + weight * layer_loss
+                    losses[f'intermediate_ctc/layer_{layer_key}'] = layer_loss.item()
 
-            total_loss = total_loss + self.self_conditioned_ctc_weight * sc_losses
-            losses['self_conditioned_ctc'] = sc_losses.item()
+                total_loss = total_loss + self.intermediate_ctc_weight * layer_losses
+                losses['intermediate_ctc'] = layer_losses.item()
 
-        if self.enable_frame_classifier and self.frame_weight > 0:
-            frame_logits = model_outputs.get('frame_phoneme_logits')
-            if frame_logits is not None:
-                frame_targets = self._build_frame_targets(text_input, text_input_length, mel_input_length, frame_logits.size(1))
-                frame_loss = self.criterion['frame_ce'](frame_logits.reshape(-1, frame_logits.size(2)),
-                                                        frame_targets.view(-1))
-                total_loss = total_loss + self.frame_weight * frame_loss
-                losses['frame_phoneme'] = frame_loss.item()
+            self_conditioned_outputs = model_outputs.get('self_conditioned_ctc_logits') or {}
+            if (
+                self.self_conditioned_ctc_enabled
+                and self.self_conditioned_ctc_weight > 0.0
+                and isinstance(self_conditioned_outputs, dict)
+                and self_conditioned_outputs
+            ):
+                sc_losses = torch.zeros(1, device=self.device)
+                for layer_key, logits in self_conditioned_outputs.items():
+                    if not isinstance(logits, torch.Tensor):
+                        continue
+                    sc_loss = self._compute_ctc_loss(logits, text_input, mel_input_length, text_input_length, mix_metadata)
+                    weight = float(self.self_conditioned_ctc_layer_weights.get(str(layer_key), 1.0))
+                    sc_losses = sc_losses + weight * sc_loss
+                    losses[f'self_conditioned_ctc/layer_{layer_key}'] = sc_loss.item()
+
+                total_loss = total_loss + self.self_conditioned_ctc_weight * sc_losses
+                losses['self_conditioned_ctc'] = sc_losses.item()
+
+            if self.enable_frame_classifier and self.frame_weight > 0:
+                frame_logits = model_outputs.get('frame_phoneme_logits')
+                if frame_logits is not None:
+                    frame_targets = self._build_frame_targets(text_input, text_input_length, mel_input_length, frame_logits.size(1))
+                    frame_loss = self.criterion['frame_ce'](frame_logits.reshape(-1, frame_logits.size(2)),
+                                                            frame_targets.view(-1))
+                    total_loss = total_loss + self.frame_weight * frame_loss
+                    losses['frame_phoneme'] = frame_loss.item()
+                else:
+                    frame_loss = torch.zeros(1, device=self.device)
             else:
                 frame_loss = torch.zeros(1, device=self.device)
-        else:
-            frame_loss = torch.zeros(1, device=self.device)
 
-        if self.enable_speaker and self.speaker_weight > 0:
-            speaker_logits = model_outputs.get('speaker_logits')
-            if speaker_logits is not None:
-                loss_speaker = self.criterion['speaker_ce'](speaker_logits, speaker_ids)
-                total_loss = total_loss + self.speaker_weight * loss_speaker
-                speaker_pred = torch.argmax(speaker_logits, dim=1)
-                speaker_acc = torch.eq(speaker_pred, speaker_ids).float().mean().item()
-                losses['speaker'] = loss_speaker.item()
-                losses['speaker_acc'] = speaker_acc
+            if self.enable_speaker and self.speaker_weight > 0:
+                speaker_logits = model_outputs.get('speaker_logits')
+                if speaker_logits is not None:
+                    loss_speaker = self.criterion['speaker_ce'](speaker_logits, speaker_ids)
+                    total_loss = total_loss + self.speaker_weight * loss_speaker
+                    speaker_pred = torch.argmax(speaker_logits, dim=1)
+                    speaker_acc = torch.eq(speaker_pred, speaker_ids).float().mean().item()
+                    losses['speaker'] = loss_speaker.item()
+                    losses['speaker_acc'] = speaker_acc
+                else:
+                    loss_speaker = torch.zeros(1, device=self.device)
             else:
                 loss_speaker = torch.zeros(1, device=self.device)
-        else:
-            loss_speaker = torch.zeros(1, device=self.device)
 
-        if self.enable_pronunciation_error and self.pron_error_weight > 0:
-            pron_logits = model_outputs.get('pron_error_logits')
-            if pron_logits is not None:
-                pron_targets = self._build_pronunciation_targets(text_input, text_input_length, pron_logits.size(1))
-                pron_loss = self.criterion['pron_error_ce'](pron_logits.reshape(-1, pron_logits.size(2)),
-                                                            pron_targets.view(-1))
-                total_loss = total_loss + self.pron_error_weight * pron_loss
-                pron_pred = torch.argmax(pron_logits, dim=2)
-                pron_acc = self._sequence_accuracy(pron_pred, pron_targets)
-                losses['pronunciation_error'] = pron_loss.item()
-                losses['pronunciation_error_acc'] = pron_acc
+            if self.enable_pronunciation_error and self.pron_error_weight > 0:
+                pron_logits = model_outputs.get('pron_error_logits')
+                if pron_logits is not None:
+                    pron_targets = self._build_pronunciation_targets(text_input, text_input_length, pron_logits.size(1))
+                    pron_loss = self.criterion['pron_error_ce'](pron_logits.reshape(-1, pron_logits.size(2)),
+                                                                pron_targets.view(-1))
+                    total_loss = total_loss + self.pron_error_weight * pron_loss
+                    pron_pred = torch.argmax(pron_logits, dim=2)
+                    pron_acc = self._sequence_accuracy(pron_pred, pron_targets)
+                    losses['pronunciation_error'] = pron_loss.item()
+                    losses['pronunciation_error_acc'] = pron_acc
+                else:
+                    pron_loss = torch.zeros(1, device=self.device)
             else:
                 pron_loss = torch.zeros(1, device=self.device)
-        else:
-            pron_loss = torch.zeros(1, device=self.device)
 
-        if self.use_diagonal_attention_prior and s2s_attn is not None:
-            loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
-            total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
-            losses['diag_attn'] = loss_diagonal.item()
-        
-        loss = total_loss
-        loss.backward()
-        torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
-        self.optimizer.step()
-        self.scheduler.step()
+            if self.use_diagonal_attention_prior and s2s_attn is not None:
+                loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
+                total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
+                losses['diag_attn'] = loss_diagonal.item()
+
+
+        loss = total_loss.float()
+        if self.grad_scaler_enabled:
+            scale_before = self.grad_scaler.get_scale()
+            self.grad_scaler.scale(loss).backward()
+            self.grad_scaler.unscale_(self.optimizer)
+            torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
+            self.grad_scaler.step(self.optimizer)
+            self.grad_scaler.update()
+            if self.scheduler is not None:
+                scale_after = self.grad_scaler.get_scale()
+                if scale_after >= scale_before:
+                    self.scheduler.step()
+        else:
+            loss.backward()
+            torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
+            self.optimizer.step()
+            if self.scheduler is not None:
+                self.scheduler.step()
+
         losses['loss'] = loss.item()
         if 'ctc' not in losses:
             losses['ctc'] = loss_ctc.item()
@@ -864,8 +930,9 @@ class Trainer(object):
             )
             mel_mask = self.model.length_to_mask(mel_input_length)
             text_mask = self._maybe_create_text_mask(text_input_length)
-            model_outputs = self.model(
-                mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
+            with self._autocast_context():
+                model_outputs = self.model(
+                    mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
             ppgs = model_outputs.get('ctc_logits')
             s2s_pred = model_outputs.get('s2s_logits')


### PR DESCRIPTION
## Summary
- add `training.mixed_precision` configuration to enable autocast and GradScaler
- integrate optional AMP execution paths into the trainer for train and eval
- refresh utility notebooks with notes about the new configuration toggle

## Testing
- python -m compileall trainer.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d7c0eb233083328ce367fbbbeee9fc