### PR TITLE
Add configurable fused optimizer support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -110,6 +110,21 @@ stabilization:
 optimizer_params:
   lr: 0.0005
   pct_start: 0.1
+  weight_decay: 0.0005
+  betas: [0.9, 0.98]
+  eps: 1.0e-9
+  fused_optimizers:
+    enabled: true
+    priority:
+      - torch
+      - apex
+      - foreach
+    torch:
+      enabled: true
+    apex:
+      enabled: false
+    foreach:
+      enabled: true
 
 # this is a very basic early stopping based off learning rate - when it falls to 0 and remains there for 3 epochs, the training stops
 enable_early_stopping: True

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -467,6 +467,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -468,6 +468,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -358,6 +358,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -491,6 +491,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -636,6 +636,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -585,6 +585,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -473,6 +473,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -597,6 +597,44 @@
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Inspect fused optimizer configuration\n",
+    "import yaml\n",
+    "\n",
+    "def _load__fused_config_root():\n",
+    "    if 'config' in globals() and isinstance(config, dict):\n",
+    "        return config\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        return yaml.safe_load(_f)\n",
+    "\n",
+    "def _normalize_backend_entry(entry, default_enabled):\n",
+    "    if isinstance(entry, dict):\n",
+    "        enabled = entry.get('enabled', default_enabled)\n",
+    "        rest = {k: v for k, v in entry.items() if k != 'enabled'}\n",
+    "        return bool(enabled), rest\n",
+    "    if entry is None:\n",
+    "        return bool(default_enabled), {}\n",
+    "    return bool(entry), {}\n",
+    "\n",
+    "_fused_root_cfg = _load__fused_config_root()\n",
+    "optimizer_cfg = _fused_root_cfg.get('optimizer_params', {}) if isinstance(_fused_root_cfg, dict) else {}\n",
+    "fused_cfg = optimizer_cfg.get('fused_optimizers', {}) if isinstance(optimizer_cfg, dict) else {}\n",
+    "fused_enabled = bool(fused_cfg.get('enabled', False))\n",
+    "priority = fused_cfg.get('priority', ['torch', 'apex', 'foreach'])\n",
+    "print(f\"fused optimizers enabled --> {fused_enabled}\")\n",
+    "print(f\"fused optimizer priority --> {priority}\")\n",
+    "for backend in ('torch', 'apex', 'foreach'):\n",
+    "    backend_enabled, backend_cfg = _normalize_backend_entry(fused_cfg.get(backend), fused_enabled)\n",
+    "    print(f\"{backend} backend enabled --> {backend_enabled}\")\n",
+    "    if backend_cfg:\n",
+    "        print(f\"  extra settings: {backend_cfg}\")\n"
+   ]
   }
  ],
  "metadata": {

--- a/optimizers.py
+++ b/optimizers.py
@@ -8,6 +8,11 @@ from torch.optim import Optimizer
 from functools import reduce
 from torch.optim import AdamW
 
+try:
+    from typing import Iterable, List, Sequence, Tuple, Union, Dict, Any
+except ImportError:  # pragma: no cover - typing is available in stdlib, defensive only
+    Iterable = List = Sequence = Tuple = Union = Dict = Any = None
+
 class MultiOptimizer:
     def __init__(self, optimizers={}, schedulers={}):
         self.optimizers = optimizers
@@ -47,24 +52,167 @@ class MultiOptimizer:
             _ = [self.schedulers[key].step(*args) for key in self.keys]
 
 
+def _as_parameter_list(params):
+    if isinstance(params, (list, tuple)):
+        return list(params)
+    if isinstance(params, nn.Parameter):
+        return [params]
+    return list(params)
+
+
+def _materialize_param_groups(param_spec):
+    if isinstance(param_spec, dict):
+        param_spec = [param_spec]
+    elif not isinstance(param_spec, (list, tuple)):
+        param_spec = list(param_spec)
+
+    materialized = []
+    for group in param_spec:
+        if isinstance(group, dict):
+            new_group = dict(group)
+            new_group['params'] = _as_parameter_list(new_group.get('params', []))
+            materialized.append(new_group)
+        else:
+            materialized.append(group)
+    return materialized
+
+
+def _clone_param_groups(materialized):
+    cloned = []
+    for group in materialized:
+        if isinstance(group, dict):
+            cloned_group = dict(group)
+            cloned_group['params'] = list(cloned_group.get('params', []))
+            cloned.append(cloned_group)
+        else:
+            cloned.append(group)
+    return cloned
+
+
+def _resolve_backend_config(fused_cfg, backend, global_default):
+    entry = fused_cfg.get(backend)
+    if isinstance(entry, dict):
+        enabled = entry.get('enabled', global_default)
+        extra = {k: v for k, v in entry.items() if k != 'enabled'}
+        return bool(enabled), extra
+    if entry is None:
+        return bool(global_default), {}
+    return bool(entry), {}
+
+
+def _attempt_torch_fused_adamw(param_groups, *, lr, weight_decay, betas, eps):
+    kwargs = dict(lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, fused=True)
+    try:
+        return AdamW(param_groups, **kwargs)
+    except TypeError as exc:
+        print(f"Torch fused AdamW is unavailable: {exc}")
+    except RuntimeError as exc:
+        print(f"Failed to initialise torch fused AdamW: {exc}")
+    return None
+
+
+def _attempt_torch_foreach_adamw(param_groups, *, lr, weight_decay, betas, eps):
+    kwargs = dict(lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, foreach=True)
+    try:
+        return AdamW(param_groups, **kwargs)
+    except TypeError as exc:
+        print(f"AdamW foreach implementation is unavailable: {exc}")
+    except RuntimeError as exc:
+        print(f"Failed to initialise AdamW with foreach=True: {exc}")
+    return None
+
+
+def _attempt_apex_fused_adam(param_groups, *, lr, weight_decay, betas, eps, extra_kwargs=None):
+    try:
+        from apex.optimizers import FusedAdam  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        print(f"Apex FusedAdam could not be imported: {exc}")
+        return None
+
+    fused_kwargs = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay, adam_w_mode=True)
+    if isinstance(extra_kwargs, dict):
+        fused_kwargs.update(extra_kwargs)
+
+    try:
+        return FusedAdam(param_groups, **fused_kwargs)
+    except Exception as exc:
+        print(f"Failed to initialise Apex FusedAdam: {exc}")
+    return None
+
+
+def _select_optimizer_backend(materialized_groups, optimizer_params):
+    fused_cfg = optimizer_params.get('fused_optimizers', {}) if isinstance(optimizer_params, dict) else {}
+    fused_enabled = bool(fused_cfg.get('enabled', False))
+
+    priority = fused_cfg.get('priority', []) if isinstance(fused_cfg, dict) else []
+    if isinstance(priority, str):
+        priority = [priority]
+
+    if not priority:
+        priority = [backend for backend in ('torch', 'apex', 'foreach')
+                    if bool(_resolve_backend_config(fused_cfg, backend, fused_enabled)[0])]
+
+    lr = optimizer_params.get('lr', 1e-4)
+    weight_decay = optimizer_params.get('weight_decay', 5e-4)
+    betas = optimizer_params.get('betas', (0.9, 0.98))
+    if isinstance(betas, list):
+        betas = tuple(betas)
+    eps = optimizer_params.get('eps', 1e-9)
+
+    for backend in priority:
+        backend = str(backend).lower()
+        enabled, backend_cfg = _resolve_backend_config(fused_cfg, backend, fused_enabled)
+        if not enabled:
+            continue
+
+        param_groups = _clone_param_groups(materialized_groups)
+
+        if backend == 'torch':
+            optimizer = _attempt_torch_fused_adamw(param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps)
+        elif backend == 'apex':
+            optimizer = _attempt_apex_fused_adam(param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps, extra_kwargs=backend_cfg)
+        elif backend == 'foreach':
+            optimizer = _attempt_torch_foreach_adamw(param_groups, lr=lr, weight_decay=weight_decay, betas=betas, eps=eps)
+        else:
+            print(f"Unknown fused optimizer backend '{backend}' requested; skipping.")
+            optimizer = None
+
+        if optimizer is not None:
+            print(f"Using fused optimizer backend: {backend}")
+            return optimizer
+
+    return None
+
+
 def build_optimizer(parameters):
     optimizer, scheduler = _define_optimizer(parameters)
     return optimizer, scheduler
 
 def _define_optimizer(params):
-    optimizer_params = params['optimizer_params']
+    optimizer_params = params.get('optimizer_params', {}) or {}
     sch_params = params['scheduler_params']
-    optimizer = AdamW(
-        params['params'],
-        lr=optimizer_params.get('lr', 1e-4),
-        weight_decay=optimizer_params.get('weight_decay', 5e-4),
-        betas=(0.9, 0.98),
-        eps=1e-9)
+    materialized_groups = _materialize_param_groups(params['params'])
+
+    optimizer = _select_optimizer_backend(materialized_groups, optimizer_params)
+    if optimizer is None:
+        lr = optimizer_params.get('lr', 1e-4)
+        weight_decay = optimizer_params.get('weight_decay', 5e-4)
+        betas = optimizer_params.get('betas', (0.9, 0.98))
+        if isinstance(betas, list):
+            betas = tuple(betas)
+        eps = optimizer_params.get('eps', 1e-9)
+        optimizer = AdamW(
+            _clone_param_groups(materialized_groups),
+            lr=lr,
+            weight_decay=weight_decay,
+            betas=betas,
+            eps=eps)
+        print("Using standard AdamW optimizer")
+
     scheduler = _define_scheduler(optimizer, sch_params)
     return optimizer, scheduler
 
 def _define_scheduler(optimizer, params):
-    print(params)
     scheduler = torch.optim.lr_scheduler.OneCycleLR(
         optimizer,
         max_lr=params.get('max_lr', 5e-4),

--- a/train.py
+++ b/train.py
@@ -333,6 +333,7 @@ def main(config_path):
 
     model = build_model(model_params=model_params)
 
+    optimizer_config = cfg_get_nested(config, 'optimizer_params', {}) or {}
     scheduler_params = {
             'max_lr': float(cfg_get_nested( config, 'optimizer_params.lr', 5e-4)),
             'pct_start': float(cfg_get_nested( config, 'optimizer_params.pct_start', 0.1)),
@@ -344,7 +345,7 @@ def main(config_path):
 
     model.to(device)
     optimizer, scheduler = build_optimizer(
-        {"params": model.parameters(), "optimizer_params":{}, "scheduler_params": scheduler_params})
+        {"params": model.parameters(), "optimizer_params": optimizer_config, "scheduler_params": scheduler_params})
 
     blank_index = sorted_train_dataloader.dataset.text_cleaner.word_index_dictionary[" "] # get blank index
     criterion = build_criterion(critic_params={


### PR DESCRIPTION
## Summary
- add fused optimizer backend selection utilities covering torch fused AdamW, foreach AdamW, and Apex FusedAdam fallbacks
- expose optimizer hyperparameters and backend toggles via Configs/config.yml and propagate them through training
- extend all Utils notebooks with a helper cell that prints the active fused optimizer configuration for quick validation

## Testing
- python -m compileall optimizers.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d82f75ad6c8332b3a04d3e2ff1f73f