### PR TITLE
Add configurable curriculum batch-size scheduling

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -3,6 +3,35 @@ save_freq: 10
 device: "cuda"
 epochs: 200
 batch_size: 64
+
+curriculum:
+  batch_growth:
+    enabled: false
+    base_batch_size: 64
+    min_batch_size: 1
+    max_batch_size: null
+    enforce_monotonic: true
+    strategies:
+      milestones:
+        enabled: false
+        schedule:
+          - epoch: 1
+            batch_size: 32
+          - epoch: 5
+            batch_size: 64
+      linear:
+        enabled: false
+        start_epoch: 1
+        end_epoch: 10
+        start_batch_size: 32
+        end_batch_size: 64
+      exponential:
+        enabled: false
+        start_epoch: 1
+        end_epoch: 10
+        start_batch_size: 16
+        growth_factor: 1.5
+        target_batch_size: 64
 pretrained_model: true
 load_only_params: false
 train_data: "Data/train_list.txt"

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "35cdd623",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8e81fe76",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e477161c",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "be7878ac",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "02e57611",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3174d70a",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9e96737e",
    "metadata": {},
    "source": [

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -2,6 +2,16 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Curriculum batch-size scheduling\n",
+    "Batch-size growth during training is now controlled through the `curriculum.batch_growth` section of `Configs/config.yml`. Enable the section to warm up with smaller mini-batches and progressively scale them using the `milestones`, `linear`, or `exponential` strategies. Each strategy can be toggled independently so you can combine or disable them as experiments require.\n",
+    "\n",
+    "When running this notebook, adjust the curriculum settings in the config before launching any training or evaluation cells to ensure the loaders reflect the desired batch-size schedule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b7073371",
    "metadata": {},
    "source": [

--- a/train.py
+++ b/train.py
@@ -175,6 +175,165 @@ def cfg_get_nested(cfg: dict, path, default=None, sep="."):
             return default
     return cur
 
+
+def _coerce_int(value, default=None, minimum=None):
+    try:
+        if isinstance(value, bool):
+            raise TypeError
+        int_value = int(float(value))
+    except (TypeError, ValueError):
+        return default
+    if minimum is not None:
+        int_value = max(int_value, minimum)
+    return int_value
+
+
+def _parse_milestone_schedule(config, total_epochs):
+    if not isinstance(config, dict):
+        return {}
+    if not bool(config.get('enabled', False)):
+        return {}
+
+    raw_schedule = config.get('schedule')
+    if raw_schedule is None:
+        raw_schedule = config.get('values')
+    if raw_schedule is None:
+        raw_schedule = config.get('milestones')
+
+    entries = []
+    if isinstance(raw_schedule, dict):
+        raw_iter = raw_schedule.items()
+    else:
+        raw_iter = raw_schedule or []
+
+    for item in raw_iter:
+        if isinstance(raw_schedule, dict):
+            epoch, batch_size = item
+            epoch = _coerce_int(epoch, None, minimum=1)
+            batch_size = _coerce_int(batch_size, None, minimum=1)
+        elif isinstance(item, dict):
+            epoch = _coerce_int(item.get('epoch') or item.get('start_epoch') or item.get('at'), None, minimum=1)
+            batch_size = _coerce_int(item.get('batch_size') or item.get('value') or item.get('size'), None, minimum=1)
+        else:
+            continue
+        if epoch is None or batch_size is None:
+            continue
+        entries.append((epoch, batch_size))
+
+    if not entries:
+        return {}
+
+    entries.sort(key=lambda x: x[0])
+    schedule = {}
+    pointer = 0
+    current_batch = None
+    while pointer < len(entries) and entries[pointer][0] <= 1:
+        current_batch = entries[pointer][1]
+        pointer += 1
+    for epoch in range(1, total_epochs + 1):
+        while pointer < len(entries) and epoch >= entries[pointer][0]:
+            current_batch = entries[pointer][1]
+            pointer += 1
+        if current_batch is not None:
+            schedule[epoch] = current_batch
+    return schedule
+
+
+def build_batch_size_schedule(config, default_batch_size, total_epochs):
+    if total_epochs <= 0:
+        return {}, False
+
+    schedule = {epoch: default_batch_size for epoch in range(1, total_epochs + 1)}
+    if not isinstance(config, dict) or not bool(config.get('enabled', False)):
+        return schedule, False
+
+    base_batch_size = _coerce_int(config.get('base_batch_size'), default_batch_size, minimum=1)
+    schedule = {epoch: base_batch_size for epoch in range(1, total_epochs + 1)}
+
+    has_override = base_batch_size != default_batch_size
+
+    strategies = config.get('strategies', {}) or {}
+    if not isinstance(strategies, dict):
+        strategies = {}
+
+    milestone_values = _parse_milestone_schedule(strategies.get('milestones'), total_epochs)
+    if milestone_values:
+        for epoch, value in milestone_values.items():
+            schedule[epoch] = value
+        has_override = True
+
+    linear_cfg = strategies.get('linear', {})
+    if isinstance(linear_cfg, dict) and bool(linear_cfg.get('enabled', False)):
+        start_epoch = _coerce_int(linear_cfg.get('start_epoch'), 1, minimum=1)
+        end_epoch = _coerce_int(linear_cfg.get('end_epoch'), total_epochs, minimum=1)
+        if end_epoch < start_epoch:
+            start_epoch, end_epoch = end_epoch, start_epoch
+        span = max(end_epoch - start_epoch, 1)
+        start_batch = _coerce_int(linear_cfg.get('start_batch_size'), schedule.get(start_epoch, base_batch_size), minimum=1)
+        end_batch = _coerce_int(linear_cfg.get('end_batch_size'), default_batch_size, minimum=1)
+        if end_batch is None:
+            end_batch = schedule.get(end_epoch, base_batch_size)
+        for epoch in range(start_epoch, end_epoch + 1):
+            position = (epoch - start_epoch) / span
+            target = start_batch + position * (end_batch - start_batch)
+            schedule[epoch] = max(schedule.get(epoch, base_batch_size), int(round(target)))
+        has_override = True
+
+    exp_cfg = strategies.get('exponential', {})
+    if isinstance(exp_cfg, dict) and bool(exp_cfg.get('enabled', False)):
+        start_epoch = _coerce_int(exp_cfg.get('start_epoch'), 1, minimum=1)
+        end_epoch = _coerce_int(exp_cfg.get('end_epoch'), total_epochs, minimum=1)
+        if end_epoch < start_epoch:
+            start_epoch, end_epoch = end_epoch, start_epoch
+        growth_factor = exp_cfg.get('growth_factor', 2.0)
+        try:
+            growth_factor = float(growth_factor)
+        except (TypeError, ValueError):
+            growth_factor = 2.0
+        growth_factor = max(1.0, growth_factor)
+        start_batch = _coerce_int(exp_cfg.get('start_batch_size'), schedule.get(start_epoch, base_batch_size), minimum=1)
+        target_batch = exp_cfg.get('target_batch_size', exp_cfg.get('end_batch_size'))
+        target_batch = _coerce_int(target_batch, None, minimum=1)
+        for epoch in range(start_epoch, end_epoch + 1):
+            steps = epoch - start_epoch
+            value = start_batch * (growth_factor ** steps)
+            if target_batch is not None:
+                value = min(value, target_batch)
+            schedule[epoch] = max(schedule.get(epoch, base_batch_size), int(round(value)))
+        has_override = True
+
+    min_batch = _coerce_int(config.get('min_batch_size'), 1, minimum=1)
+    max_batch = config.get('max_batch_size')
+    max_batch = _coerce_int(max_batch, None, minimum=1)
+    enforce_monotonic = bool(config.get('enforce_monotonic', True))
+
+    previous = None
+    for epoch in range(1, total_epochs + 1):
+        value = schedule.get(epoch, base_batch_size)
+        value = int(round(value))
+        if max_batch is not None:
+            value = min(value, max_batch)
+        if value < min_batch:
+            value = min_batch
+        if enforce_monotonic and previous is not None and value < previous:
+            value = previous
+        schedule[epoch] = value
+        previous = value
+
+    has_override = has_override or any(schedule[epoch] != default_batch_size for epoch in schedule)
+    return schedule, has_override
+
+
+def summarise_schedule(schedule):
+    summary = []
+    last_value = None
+    for epoch in sorted(schedule.keys()):
+        value = schedule[epoch]
+        if value != last_value:
+            summary.append((epoch, value))
+            last_value = value
+    return summary
+
 class EarlyStoppingWithNoLearningRate:
     def __init__(self, patience=5):
         self.patience = patience  # Number of epochs to wait for improvement
@@ -258,35 +417,59 @@ def main(config_path):
 
     collate_config = {'return_speaker_ids': True}
 
-    sorted_train_dataloader = build_dataloader(train_list_sorted,
-                                        batch_size=batch_size,
-                                        num_workers=train_num_workers,
-                                        dataset_config=dataset_params,
-                                        device=device,
-                                        collate_config=collate_config)
-    shuffled_train_dataloader = build_dataloader(train_entries,
-                                            batch_size=batch_size,
-                                            num_workers=train_num_workers,
-                                            dataset_config=dataset_params,
-                                            device=device,
-                                            lengths=train_durations,
-                                            bucket_sampler_config=train_bucket_sampler_config,
-                                            collate_config=collate_config)
+    curriculum_config = cfg_get_nested(config, 'curriculum.batch_growth', {}) or {}
+    batch_schedule, schedule_enabled = build_batch_size_schedule(curriculum_config, batch_size, epochs)
+    current_batch_size = batch_schedule.get(1, batch_size)
 
-    sorted_val_dataloader = build_dataloader(val_list_sorted,
-                                      batch_size=batch_size,
-                                      validation=True,
-                                      num_workers=val_num_workers,
-                                      device=device,
-                                      dataset_config=dataset_params,
-                                      collate_config=collate_config)
-    shuffled_val_dataloader = build_dataloader(val_entries,
-                                          batch_size=batch_size,
-                                          validation=True,
-                                          num_workers=val_num_workers,
-                                          device=device,
-                                          dataset_config=dataset_params,
-                                          collate_config=collate_config)
+    if schedule_enabled:
+        print("Curriculum batch-size schedule (epoch -> batch size):")
+        for epoch_marker, batch_value in summarise_schedule(batch_schedule):
+            print(f"  epoch {epoch_marker}: batch_size = {batch_value}")
+
+    def create_dataloaders_for_batch_size(target_batch_size):
+        target_batch_size = int(target_batch_size)
+        sorted_train = build_dataloader(
+            train_list_sorted,
+            batch_size=target_batch_size,
+            num_workers=train_num_workers,
+            dataset_config=dataset_params,
+            device=device,
+            collate_config=collate_config,
+        )
+        shuffled_train = build_dataloader(
+            train_entries,
+            batch_size=target_batch_size,
+            num_workers=train_num_workers,
+            dataset_config=dataset_params,
+            device=device,
+            lengths=train_durations,
+            bucket_sampler_config=train_bucket_sampler_config,
+            collate_config=collate_config,
+        )
+        sorted_val = build_dataloader(
+            val_list_sorted,
+            batch_size=target_batch_size,
+            validation=True,
+            num_workers=val_num_workers,
+            device=device,
+            dataset_config=dataset_params,
+            collate_config=collate_config,
+        )
+        shuffled_val = build_dataloader(
+            val_entries,
+            batch_size=target_batch_size,
+            validation=True,
+            num_workers=val_num_workers,
+            device=device,
+            dataset_config=dataset_params,
+            collate_config=collate_config,
+        )
+        return sorted_train, shuffled_train, sorted_val, shuffled_val
+
+    (sorted_train_dataloader,
+     shuffled_train_dataloader,
+     sorted_val_dataloader,
+     shuffled_val_dataloader) = create_dataloaders_for_batch_size(current_batch_size)
 
     word_indexes = set(
         line.strip() for line in open(cfg_get_nested( config, 'phoneme_maps_path', 'Data/word_index_dict.txt'))
@@ -445,7 +628,38 @@ def main(config_path):
         print(f"Unrecognized value for load_checkpoint config option, starting training from epoch 1 - {pretrained_model}")
         start_epoch = 1
 
+    current_batch_size = trainer.current_batch_size or current_batch_size
+    initial_target_batch_size = batch_schedule.get(start_epoch, current_batch_size)
+    if initial_target_batch_size != current_batch_size:
+        (sorted_train_dataloader,
+         shuffled_train_dataloader,
+         sorted_val_dataloader,
+         shuffled_val_dataloader) = create_dataloaders_for_batch_size(initial_target_batch_size)
+        trainer.update_dataloaders(
+            sorted_train=sorted_train_dataloader,
+            shuffled_train=shuffled_train_dataloader,
+            sorted_val=sorted_val_dataloader,
+            shuffled_val=shuffled_val_dataloader,
+        )
+        current_batch_size = initial_target_batch_size
+        logger.info(f"[Curriculum] Resumed at epoch {start_epoch} with batch size {current_batch_size}")
+
     for epoch in range(start_epoch, epochs+1):
+        target_batch_size = batch_schedule.get(epoch, current_batch_size)
+        if target_batch_size != current_batch_size:
+            (sorted_train_dataloader,
+             shuffled_train_dataloader,
+             sorted_val_dataloader,
+             shuffled_val_dataloader) = create_dataloaders_for_batch_size(target_batch_size)
+            trainer.update_dataloaders(
+                sorted_train=sorted_train_dataloader,
+                shuffled_train=shuffled_train_dataloader,
+                sorted_val=sorted_val_dataloader,
+                shuffled_val=shuffled_val_dataloader,
+            )
+            current_batch_size = target_batch_size
+            logger.info(f"[Curriculum] Updated batch size to {current_batch_size} for epoch {epoch}")
+
         train_results = trainer._train_epoch()
         eval_results = trainer._eval_epoch()
 

--- a/trainer.py
+++ b/trainer.py
@@ -77,6 +77,7 @@ class Trainer(object):
         self.diagonal_attention_prior_weight = diagonal_attention_prior_weight
         self.maxm_mem_usage = 0
         self.steps_per_epoch = steps_per_epoch if steps_per_epoch is None else int(steps_per_epoch)
+        self.current_batch_size = self._infer_batch_size(self.train_dataloader)
         self.ctc_weight = ctc_weight
         self.s2s_weight = s2s_weight
         self.frame_weight = frame_weight
@@ -182,6 +183,15 @@ class Trainer(object):
             if self.shuffled_val_dataloader is not None:
                 self.val_dataloader = self.shuffled_val_dataloader
 
+        if self.train_dataloader is not None and self.steps_per_epoch is None:
+            try:
+                self.steps_per_epoch = len(self.train_dataloader)
+            except TypeError:
+                self.steps_per_epoch = None
+
+        if self.current_batch_size is None:
+            self.current_batch_size = self._infer_batch_size(self.train_dataloader)
+
     @staticmethod
     def _parse_intermediate_layer_weights(layers_config):
         weights = {}
@@ -209,6 +219,57 @@ class Trainer(object):
                 continue
 
         return weights
+
+    @staticmethod
+    def _infer_batch_size(dataloader):
+        if dataloader is None:
+            return None
+        batch_size = getattr(dataloader, 'batch_size', None)
+        if batch_size is not None:
+            try:
+                return int(batch_size)
+            except (TypeError, ValueError):
+                pass
+        batch_sampler = getattr(dataloader, 'batch_sampler', None)
+        if batch_sampler is not None:
+            sampler_batch_size = getattr(batch_sampler, 'batch_size', None)
+            if sampler_batch_size is not None:
+                try:
+                    return int(sampler_batch_size)
+                except (TypeError, ValueError):
+                    return None
+        return None
+
+    def update_dataloaders(self,
+                           sorted_train=None,
+                           shuffled_train=None,
+                           sorted_val=None,
+                           shuffled_val=None):
+        if sorted_train is not None:
+            self.sorted_train_dataloader = sorted_train
+        if shuffled_train is not None:
+            self.shuffled_train_dataloader = shuffled_train
+        if sorted_val is not None:
+            self.sorted_val_dataloader = sorted_val
+        if shuffled_val is not None:
+            self.shuffled_val_dataloader = shuffled_val
+
+        if self._sortagrad_active or self.shuffled_train_dataloader is None:
+            self.train_dataloader = self.sorted_train_dataloader
+        else:
+            self.train_dataloader = self.shuffled_train_dataloader or self.sorted_train_dataloader
+
+        if self._sortagrad_active or self.shuffled_val_dataloader is None:
+            self.val_dataloader = self.sorted_val_dataloader or self.shuffled_val_dataloader
+        else:
+            self.val_dataloader = self.shuffled_val_dataloader or self.sorted_val_dataloader
+
+        try:
+            self.steps_per_epoch = len(self.train_dataloader)
+        except (TypeError, ValueError, AttributeError):
+            self.steps_per_epoch = None
+
+        self.current_batch_size = self._infer_batch_size(self.train_dataloader)
 
     @staticmethod
     def _parse_entropy_regularization_targets(targets_config, root_config):
@@ -343,6 +404,11 @@ class Trainer(object):
                 self.logger.info("")
 
         self._sortagrad_active = False
+        try:
+            self.steps_per_epoch = len(self.train_dataloader)
+        except (TypeError, ValueError, AttributeError):
+            self.steps_per_epoch = None
+        self.current_batch_size = self._infer_batch_size(self.train_dataloader)
 
     def handle_sortagrad_after_resume(self):
         if not self._sortagrad_active:
@@ -881,6 +947,7 @@ class Trainer(object):
 
         train_losses = defaultdict(list)
         self.model.train()
+        current_batch_size = self.current_batch_size or self._infer_batch_size(self.train_dataloader)
         for train_steps_per_epoch, batch in enumerate(tqdm(self.train_dataloader, desc="[train]"), 1):
             losses = self.run(batch)
             for key, value in losses.items():
@@ -888,6 +955,8 @@ class Trainer(object):
 
         train_losses = {key: np.mean(value) for key, value in train_losses.items()}
         train_losses['train/learning_rate'] = self._get_lr()
+        if current_batch_size is not None:
+            train_losses['train/batch_size'] = current_batch_size
         self.epochs += 1
 
         gpu_id = 0


### PR DESCRIPTION
## Summary
- add a configurable `curriculum.batch_growth` section to manage milestone, linear, or exponential batch-size schedules
- update the trainer and training loop to rebuild dataloaders when the batch size grows during curriculum training and report the active batch size
- prepend notes to each Utils notebook so the new curriculum options are documented for interactive testing

## Testing
- python -m compileall train.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d84744207c8332aea8918a72e7a592