### PR TITLE
Integrate torch.compile runtime options and notebook updates

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -37,13 +37,21 @@ precision:
 
 runtime:
   torch_compile:
+    # Master switch for wrapping the model with torch.compile.
     enabled: false
+    # When true, the training graph is compiled so optimizer steps use the compiled kernels.
     compile_train: true
+    # When true, evaluation/validation runs also reuse a compiled graph.
     compile_eval: false
+    # Backend passed to torch.compile. "inductor" is the default backend in PyTorch 2.x.
     backend: inductor
+    # Optimization mode to use (e.g., default, reduce-overhead, max-autotune).
     mode: default
+    # Request full-graph capture instead of allowing graph breaks when possible.
     fullgraph: false
+    # Enable support for dynamic shapes when models require variable dimensions.
     dynamic: false
+    # Extra keyword arguments forwarded to torch.compile backend specific tunables.
     options: {}
 
 preprocess_params:

--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -35,6 +35,17 @@ precision:
       backoff_factor: 0.5
       growth_interval: 2000
 
+runtime:
+  torch_compile:
+    enabled: false
+    compile_train: true
+    compile_eval: false
+    backend: inductor
+    mode: default
+    fullgraph: false
+    dynamic: false
+    options: {}
+
 preprocess_params:
   sr: 24000
   spect_params:

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0bc3c44c",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3a03c429",
    "metadata": {},
    "source": [
@@ -482,6 +491,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "496036d8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "36da113b",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "021a8526",
    "metadata": {},
    "source": [
@@ -485,6 +494,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4480e1ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -13,9 +13,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "899a1802",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8caab0f",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -33,6 +46,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8641509a",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -335,6 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c9283ecd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,6 +372,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c532384",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4ff14398",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b7dfc159",
    "metadata": {},
    "source": [
@@ -508,6 +517,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a6cfa8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4b99c99b",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "78619d23",
    "metadata": {},
    "source": [
@@ -652,6 +661,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37b19bd9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f1d6dc08",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e188e205",
    "metadata": {},
    "source": [
@@ -602,6 +611,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2a36c28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -13,6 +13,15 @@
   },
   {
    "cell_type": "markdown",
+   "id": "28f49a3d",
+   "metadata": {},
+   "source": [
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "be174965",
    "metadata": {},
    "source": [
@@ -488,6 +497,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79f157e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -13,9 +13,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "03414ea2",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "### TorchDynamo kernel fusion controls\n",
+    "The training scripts now accept PyTorch 2.x `torch.compile` / TorchDynamo settings through `runtime.torch_compile` in `Configs/config.yml`. Enable `enabled: true` to activate kernel fusion and toggle `compile_train`/`compile_eval` independently when you want to benchmark eager vs. compiled paths inside the notebooks. Adjust `backend`, `mode`, `fullgraph`, `dynamic`, or add entries under `options` to compare different compiler strategies before launching large experiments."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bcc5053",
+   "metadata": {},
+   "source": [
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -49,6 +62,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bcf0b18c",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -187,6 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "854cb95a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,6 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "5f23fc34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,6 +612,40 @@
     "print(f\"mixed precision enabled --> {bool(mixed_precision_cfg.get('enabled', False))}\")\n",
     "print(f\"mixed precision dtype --> {mixed_precision_cfg.get('dtype', 'float16')}\")\n",
     "print(f\"grad scaler enabled --> {bool(grad_scaler_cfg.get('enabled', True))}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06091413",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "\n",
+    "\n",
+    "def _resolve_torch_compile_config(_cfg):\n",
+    "    if 'cfg_get_nested' in globals():\n",
+    "        return cfg_get_nested(_cfg, 'runtime.torch_compile', {})\n",
+    "    runtime_cfg = _cfg.get('runtime', {}) if isinstance(_cfg, dict) else {}\n",
+    "    return runtime_cfg.get('torch_compile', {}) if isinstance(runtime_cfg, dict) else {}\n",
+    "\n",
+    "if 'config' in globals():\n",
+    "    _tc_root_config = config\n",
+    "else:\n",
+    "    with open('Configs/config.yml') as _f:\n",
+    "        _tc_root_config = yaml.safe_load(_f)\n",
+    "\n",
+    "torch_compile_cfg = _resolve_torch_compile_config(_tc_root_config) or {}\n",
+    "print(f\"torch.compile enabled --> {bool(torch_compile_cfg.get('enabled', False))}\")\n",
+    "print(f\"compile train --> {bool(torch_compile_cfg.get('compile_train', True))}\")\n",
+    "print(f\"compile eval --> {bool(torch_compile_cfg.get('compile_eval', False))}\")\n",
+    "print(f\"backend --> {torch_compile_cfg.get('backend', 'inductor')}\")\n",
+    "print(f\"mode --> {torch_compile_cfg.get('mode', 'default')}\")\n",
+    "print(f\"fullgraph --> {bool(torch_compile_cfg.get('fullgraph', False))}\")\n",
+    "print(f\"dynamic shapes --> {bool(torch_compile_cfg.get('dynamic', False))}\")\n",
+    "options = torch_compile_cfg.get('options', {}) if isinstance(torch_compile_cfg, dict) else {}\n",
+    "print(f\"extra options --> {options}\")\n"
    ]
   }
  ],

--- a/train.py
+++ b/train.py
@@ -18,6 +18,7 @@ from torch.utils.tensorboard import SummaryWriter
 import click
 import importlib
 import importlib.util
+from typing import Any, Dict, Tuple
 
 # enable better memory management
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
@@ -43,6 +44,102 @@ def _load_optional_tqdm():
 
 
 _OPTIONAL_TQDM = _load_optional_tqdm()
+
+
+def _normalize_torch_compile_config(raw_config: Any) -> Dict[str, Any]:
+    """Validate and prepare ``torch.compile`` options from the YAML config."""
+
+    if not isinstance(raw_config, dict):
+        raw_config = {}
+
+    normalized: Dict[str, Any] = {}
+    normalized['enabled'] = bool(raw_config.get('enabled', False))
+    normalized['compile_train'] = bool(raw_config.get('compile_train', True))
+    normalized['compile_eval'] = bool(raw_config.get('compile_eval', False))
+
+    backend = raw_config.get('backend', 'inductor')
+    if isinstance(backend, str):
+        backend = backend.strip()
+    else:
+        backend = None
+    backend = backend or None
+    normalized['backend'] = backend
+
+    mode = raw_config.get('mode', 'default')
+    if isinstance(mode, str):
+        mode = mode.strip()
+    else:
+        mode = None
+    mode = mode or None
+    normalized['mode'] = mode
+
+    normalized['fullgraph'] = bool(raw_config.get('fullgraph', False))
+    normalized['dynamic'] = bool(raw_config.get('dynamic', False))
+
+    options = raw_config.get('options', {})
+    if not isinstance(options, dict):
+        options = {}
+    normalized['options'] = options
+
+    compile_kwargs: Dict[str, Any] = {}
+    if backend is not None:
+        compile_kwargs['backend'] = backend
+    if mode is not None:
+        compile_kwargs['mode'] = mode
+    compile_kwargs['fullgraph'] = normalized['fullgraph']
+    compile_kwargs['dynamic'] = normalized['dynamic']
+    for key, value in options.items():
+        compile_kwargs.setdefault(key, value)
+
+    normalized['torch_compile_kwargs'] = compile_kwargs
+    normalized['available'] = hasattr(torch, 'compile')
+    normalized['compiled_train'] = False
+    normalized['compile_error'] = None
+    return normalized
+
+
+def _maybe_compile_model(model: torch.nn.Module,
+                         compile_config: Dict[str, Any],
+                         logger: logging.Logger) -> Tuple[torch.nn.Module, Dict[str, Any]]:
+    """Wrap the model with ``torch.compile`` if requested and available."""
+
+    updated_config = dict(compile_config) if isinstance(compile_config, dict) else {}
+
+    should_compile = (
+        updated_config.get('enabled', False)
+        and updated_config.get('compile_train', True)
+        and updated_config.get('available', hasattr(torch, 'compile'))
+    )
+
+    if not should_compile:
+        if updated_config.get('enabled', False) and not updated_config.get('available', True):
+            logger.warning("torch.compile requested but this PyTorch build does not expose it. Falling back to eager mode.")
+        updated_config['compiled_train'] = False
+        return model, updated_config
+
+    compile_kwargs = dict(updated_config.get('torch_compile_kwargs', {}))
+    try:
+        compiled_model = torch.compile(model, **compile_kwargs)
+    except Exception as exc:  # pragma: no cover - compile failure paths
+        logger.warning(
+            "torch.compile failed for the training graph (backend=%s, mode=%s). Using eager execution instead. Error: %s",
+            compile_kwargs.get('backend', 'inductor'),
+            compile_kwargs.get('mode', 'default'),
+            exc,
+        )
+        updated_config['compiled_train'] = False
+        updated_config['compile_error'] = str(exc)
+        return model, updated_config
+
+    logger.info(
+        "Enabled torch.compile for training (backend=%s, mode=%s, fullgraph=%s, dynamic=%s)",
+        compile_kwargs.get('backend', 'inductor'),
+        compile_kwargs.get('mode', 'default'),
+        compile_kwargs.get('fullgraph', False),
+        compile_kwargs.get('dynamic', False),
+    )
+    updated_config['compiled_train'] = True
+    return compiled_model, updated_config
 
 
 def prepare_data_list(raw_data_list, root_path=""):
@@ -371,6 +468,12 @@ def main(config_path):
 
     model = build_model(model_params=model_params)
 
+    runtime_config = cfg_get_nested(config, 'runtime', {}) or {}
+    torch_compile_raw = runtime_config.get('torch_compile', {}) if isinstance(runtime_config, dict) else {}
+    torch_compile_config = _normalize_torch_compile_config(torch_compile_raw)
+
+    model, torch_compile_config = _maybe_compile_model(model, torch_compile_config, logger)
+
     total_training_steps = batch_scheduler.expected_total_steps(num_train_items)
     scheduler_params = {
             'max_lr': float(cfg_get_nested( config, 'optimizer_params.lr', 5e-4)),
@@ -423,35 +526,43 @@ def main(config_path):
 
     steps_per_epoch = len(sorted_train_dataloader) if sorted_train_dataloader is not None else len(shuffled_train_dataloader)
 
-    trainer = Trainer(model=model,
-                    criterion=criterion,
-                    optimizer=optimizer,
-                    scheduler=scheduler,
-                    config=config,
-                    device=device,
-                    sorted_train_dataloader=sorted_train_dataloader,
-                    shuffled_train_dataloader=shuffled_train_dataloader,
-                    sorted_val_dataloader=sorted_val_dataloader,
-                    shuffled_val_dataloader=shuffled_val_dataloader,
-                    logger=logger,
-                    switch_sortagrad_dataset_epoch=cfg_get_nested( config, 'sortagrad_switch_to_shuffled_dataset_epoch', 10),
-                    use_diagonal_attention_prior=(cfg_get_nested( config, 'use_diagonal_attention_prior', True) and use_s2s),
-                    diagonal_attention_prior_weight=cfg_get_nested( config, 'diagonal_attention_prior_weight', 0.1),
-                    ctc_weight=ctc_weight,
-                    s2s_weight=s2s_weight,
-                    frame_weight=frame_weight,
-                    speaker_weight=speaker_weight,
-                    pron_error_weight=pron_weight,
-                    enable_frame_classifier=frame_cfg.get('enabled', False),
-                    enable_speaker=speaker_cfg.get('enabled', False),
-                    enable_pronunciation_error=pron_cfg.get('enabled', False),
-                    mixspeech_config=mixspeech_config,
-                    intermediate_ctc_config=intermediate_ctc_config,
-                    self_conditioned_ctc_config=self_conditioned_ctc_config,
-                    entropy_regularization_config=entropy_regularization_config,
-                    memory_optimization_config=memory_optimization_config,
-                    steps_per_epoch=steps_per_epoch
-                    )
+    trainer = Trainer(
+        model=model,
+        criterion=criterion,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        config=config,
+        device=device,
+        sorted_train_dataloader=sorted_train_dataloader,
+        shuffled_train_dataloader=shuffled_train_dataloader,
+        sorted_val_dataloader=sorted_val_dataloader,
+        shuffled_val_dataloader=shuffled_val_dataloader,
+        logger=logger,
+        switch_sortagrad_dataset_epoch=cfg_get_nested(
+            config, 'sortagrad_switch_to_shuffled_dataset_epoch', 10
+        ),
+        use_diagonal_attention_prior=(
+            cfg_get_nested(config, 'use_diagonal_attention_prior', True) and use_s2s
+        ),
+        diagonal_attention_prior_weight=cfg_get_nested(
+            config, 'diagonal_attention_prior_weight', 0.1
+        ),
+        ctc_weight=ctc_weight,
+        s2s_weight=s2s_weight,
+        frame_weight=frame_weight,
+        speaker_weight=speaker_weight,
+        pron_error_weight=pron_weight,
+        enable_frame_classifier=frame_cfg.get('enabled', False),
+        enable_speaker=speaker_cfg.get('enabled', False),
+        enable_pronunciation_error=pron_cfg.get('enabled', False),
+        mixspeech_config=mixspeech_config,
+        intermediate_ctc_config=intermediate_ctc_config,
+        self_conditioned_ctc_config=self_conditioned_ctc_config,
+        entropy_regularization_config=entropy_regularization_config,
+        memory_optimization_config=memory_optimization_config,
+        torch_compile_config=torch_compile_config,
+        steps_per_epoch=steps_per_epoch,
+    )
 
     current_train_batch_size = int(initial_batch_size)
 
@@ -565,5 +676,5 @@ def main(config_path):
 
     return 0
 
-if __name__=="__main__":
+if __name__ == "__main__":
     main()

--- a/trainer.py
+++ b/trainer.py
@@ -53,6 +53,7 @@ class Trainer(object):
                  self_conditioned_ctc_config=None,
                  entropy_regularization_config=None,
                  memory_optimization_config=None,
+                 torch_compile_config=None,
                  steps_per_epoch=None):
 
         self.steps = initial_steps
@@ -166,6 +167,20 @@ class Trainer(object):
             )
         else:
             self.grad_scaler = None
+
+        compile_cfg = torch_compile_config or {}
+        if not isinstance(compile_cfg, dict):
+            compile_cfg = {}
+        self._torch_compile_config = dict(compile_cfg)
+        self._torch_compile_train_compiled = bool(self._torch_compile_config.get('compiled_train', False))
+        self._torch_compile_eval_requested = bool(
+            self._torch_compile_config.get('enabled', False)
+            and self._torch_compile_config.get('compile_eval', False)
+        )
+        self._torch_compile_kwargs = self._torch_compile_config.get('torch_compile_kwargs', {})
+        if not isinstance(self._torch_compile_kwargs, dict):
+            self._torch_compile_kwargs = {}
+        self._torch_compile_eval_model = None
 
         self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
@@ -282,22 +297,51 @@ class Trainer(object):
             return None
         return cfg
 
-    def _maybe_create_future_mask(self, length: int):
+    def _maybe_create_future_mask(self, length: int, model: nn.Module = None):
         if self.skip_future_mask_allocation:
             return None
         if length is None or length <= 0:
             return None
-        mask = self.model.get_future_mask(length, unmask_future_steps=0)
+        target_model = model if model is not None else self.model
+        mask = target_model.get_future_mask(length, unmask_future_steps=0)
         if mask is None:
             return None
         return mask.to(self.device) if hasattr(mask, 'to') else mask
 
-    def _maybe_create_text_mask(self, lengths):
+    def _maybe_create_text_mask(self, lengths, model: nn.Module = None):
         if self.skip_text_mask_allocation:
             return None
         if lengths is None:
             return None
-        return self.model.length_to_mask(lengths)
+        target_model = model if model is not None else self.model
+        return target_model.length_to_mask(lengths)
+
+    def _select_eval_model(self) -> nn.Module:
+        if self._torch_compile_train_compiled:
+            return self.model
+        if not self._torch_compile_eval_requested:
+            return self.model
+        if not hasattr(torch, 'compile'):
+            self._torch_compile_eval_requested = False
+            return self.model
+        if self._torch_compile_eval_model is None:
+            try:
+                self._torch_compile_eval_model = torch.compile(self.model, **self._torch_compile_kwargs)
+                self.logger.info(
+                    "Enabled torch.compile for evaluation (backend=%s, mode=%s, fullgraph=%s, dynamic=%s)",
+                    self._torch_compile_kwargs.get('backend', 'inductor'),
+                    self._torch_compile_kwargs.get('mode', 'default'),
+                    self._torch_compile_kwargs.get('fullgraph', False),
+                    self._torch_compile_kwargs.get('dynamic', False),
+                )
+            except Exception as exc:  # pragma: no cover - compile failure paths
+                self.logger.warning(
+                    "torch.compile failed for evaluation. Falling back to eager mode. Error: %s", exc
+                )
+                self._torch_compile_eval_requested = False
+                self._torch_compile_eval_model = None
+                return self.model
+        return self._torch_compile_eval_model
 
     def _compute_entropy_regularization(self, logits, lengths=None, key='ctc'):
         cfg = self._entropy_target_config(key)
@@ -937,7 +981,8 @@ class Trainer(object):
 
     @torch.no_grad()
     def _eval_epoch(self):
-        self.model.eval()
+        eval_model = self._select_eval_model()
+        eval_model.eval()
         eval_losses = defaultdict(list)
         eval_images = defaultdict(list)
         for eval_steps_per_epoch, batch in enumerate(tqdm(self.val_dataloader, desc="[eval]"), 1):
@@ -954,13 +999,14 @@ class Trainer(object):
                 speaker_ids = batch[4].long()
             else:
                 speaker_ids = torch.zeros(text_input.size(0), device=self.device, dtype=torch.long)
-            mel_input_length = mel_input_length // (2 ** self.model.n_down)
+            mel_input_length = mel_input_length // (2 ** eval_model.n_down)
             future_mask = self._maybe_create_future_mask(
-                mel_input.size(2) // (2 ** self.model.n_down)
+                mel_input.size(2) // (2 ** eval_model.n_down),
+                model=eval_model,
             )
-            mel_mask = self.model.length_to_mask(mel_input_length)
-            text_mask = self._maybe_create_text_mask(text_input_length)
-            model_outputs = self.model(
+            mel_mask = eval_model.length_to_mask(mel_input_length)
+            text_mask = self._maybe_create_text_mask(text_input_length, model=eval_model)
+            model_outputs = eval_model(
                 mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 
             ppgs = model_outputs.get('ctc_logits')


### PR DESCRIPTION
## Summary
- add a `runtime.torch_compile` block to the default configuration so kernel fusion can be toggled and tuned
- wrap the ASR model with `torch.compile` when enabled and extend the trainer to reuse compiled graphs during validation
- update all utility notebooks with TorchDynamo guidance and a helper cell that inspects the active compile settings

## Testing
- python -m compileall train.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e073f76483328ac477c477dfe6ef