### PR TITLE
Address AMP deprecation and checkpoint warnings

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -23,6 +23,7 @@ memory_optimizations:
     segments: 1
     min_sequence_length: 0
     use_checkpoint_sequential: true
+    use_reentrant: false
 
 precision:
   mixed_precision:

--- a/models.py
+++ b/models.py
@@ -186,6 +186,9 @@ class ASRCNN(nn.Module):
         self.gradient_checkpoint_use_sequential = bool(
             self._gradient_checkpoint_cfg.get('use_checkpoint_sequential', True)
         )
+        self.gradient_checkpoint_use_reentrant = bool(
+            self._gradient_checkpoint_cfg.get('use_reentrant', False)
+        )
 
         self.encoder_layers = nn.ModuleList()
         for layer_idx in range(1, n_layers + 1):
@@ -380,7 +383,12 @@ class ASRCNN(nn.Module):
             segments = max(1, segments)
 
             if self.gradient_checkpoint_use_sequential or len(modules) > 1:
-                x = checkpoint_sequential(modules, segments, x)
+                x = checkpoint_sequential(
+                    modules,
+                    segments,
+                    x,
+                    use_reentrant=self.gradient_checkpoint_use_reentrant,
+                )
             else:
                 def _run_modules(inp: torch.Tensor) -> torch.Tensor:
                     for module in modules:

--- a/trainer.py
+++ b/trainer.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 import numpy as np
 import torch
 from torch import nn
-from torch.cuda.amp import autocast, GradScaler
+from torch.cuda.amp import GradScaler
 from PIL import Image
 from tqdm import tqdm
 
@@ -727,7 +727,9 @@ class Trainer(object):
         autocast_dtype = self.mixed_precision_dtype if self.autocast_enabled else None
         grad_scaler = self.grad_scaler if self.grad_scaler is not None else None
 
-        with autocast(enabled=self.autocast_enabled, dtype=autocast_dtype):
+        with torch.amp.autocast(
+            "cuda", enabled=self.autocast_enabled, dtype=autocast_dtype
+        ):
             model_outputs = self.model(
                 mel_input, src_key_padding_mask=mel_mask, text_input=text_input)
 


### PR DESCRIPTION
## Summary
- switch the trainer's autocast context to the recommended torch.amp API
- allow configuring gradient checkpointing to opt into non-reentrant mode and pass the flag explicitly
- document the new checkpoint option in the default configuration

## Testing
- python -m compileall models.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e614550883329b139d4953b402ea