### PR TITLE
Add configurable LR scheduler options

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -110,7 +110,22 @@ stabilization:
 
 optimizer_params:
   lr: 0.0005
-  pct_start: 0.1
+  weight_decay: 0.0005
+  scheduler:
+    enabled: true
+    type: one_cycle  # options: one_cycle, cosine_warm_restarts
+    one_cycle:
+      pct_start: 0.1
+      final_div_factor: 5.0
+      total_steps: null
+    cosine_warm_restarts:
+      T_0_epochs: 10
+      T_0_steps: null
+      T_mult: 1
+      eta_min: 1.0e-06
+      warmup_pct: 0.1
+      warmup_steps: null
+      warmup_start_lr: 0.0
 
 # this is a very basic early stopping based off learning rate - when it falls to 0 and remains there for 3 epochs, the training stops
 enable_early_stopping: True

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ loss_weights:
 
 Each augmentation block can be toggled on or off independently through `Configs/config.yml`, allowing you to combine time warping, adaptive masking, frame dropping, VTLP, noise/reverberation mixing (including MUSAN and room impulse responses), and phoneme-level dropout as needed.
 
-Increasing the warm-up ratio (`optimizer_params.pct_start`) or reducing the batch size can also help when the number of training utterances is limited.
+Increasing the warm-up ratio (`optimizer_params.scheduler.one_cycle.pct_start`) or switching to the cosine warm-restart schedule (`optimizer_params.scheduler.type: cosine_warm_restarts`) can also help when the number of training utterances is limited. Adjust the corresponding scheduler block in `Configs/config.yml` to toggle each strategy independently.
 
 ### Languages
 This repo is set up for English with the [phonemizer](https://github.com/bootphon/phonemizer) package and espeak-ng backend. You can train it with other languages. If you would like to train for datasets in different languages, you will need to change the vocabulary file ([word_index_dict.txt](https://github.com/martinambrus/AuxiliaryASR/blob/main/word_index_dict.txt)) to contain the phonemes in your dataset. There is a utility script ([words_index_extractor.py](https://github.com/martinambrus/AuxiliaryASR/blob/main/words_index_extractor.py)) which will generate (and **_rewrite_**!) the file words_index_dict.txt when ran. Here's the syntax to use to generate this file:

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -8,14 +8,20 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "3cda6c30",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -33,6 +39,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7d94f9ac",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -335,6 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2dd321db",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -8,7 +8,9 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -8,14 +8,20 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Learning-rate scheduling**: Configure `optimizer_params.scheduler` in `Configs/config.yml` to switch between the OneCycle warm-up (tune `one_cycle.pct_start`) and the cosine decay with warm restarts (`type: cosine_warm_restarts`). Toggle each strategy independently by adjusting the scheduler `type` and its corresponding block."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "ce833e32",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -49,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "836d8767",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -187,6 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0d18d9d8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,6 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "67a6f252",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/optimizers.py
+++ b/optimizers.py
@@ -1,11 +1,8 @@
 #coding:utf-8
-import os, sys
-import os.path as osp
-import numpy as np
-import torch
-from torch import nn
-from torch.optim import Optimizer
+import math
 from functools import reduce
+
+import torch
 from torch.optim import AdamW
 
 class MultiOptimizer:
@@ -42,59 +39,207 @@ class MultiOptimizer:
 
     def scheduler(self, *args, key=None):
         if key is not None:
-            self.schedulers[key].step(*args)
+            scheduler = self.schedulers.get(key)
+            if scheduler is not None:
+                scheduler.step(*args)
         else:
-            _ = [self.schedulers[key].step(*args) for key in self.keys]
+            for scheduler in self.schedulers.values():
+                if scheduler is not None:
+                    scheduler.step(*args)
 
 
-def build_optimizer(parameters):
-    optimizer, scheduler = _define_optimizer(parameters)
+class CosineWarmupRestarts(torch.optim.lr_scheduler._LRScheduler):
+    """Cosine annealing with warm restarts and optional linear warm-up."""
+
+    def __init__(
+        self,
+        optimizer,
+        T_0,
+        T_mult=1,
+        eta_min=0.0,
+        warmup_steps=0,
+        warmup_start_lr=0.0,
+        last_epoch=-1,
+    ):
+        self.T_0 = max(1, int(T_0))
+        self.T_mult = max(1, int(T_mult))
+        self.eta_min = float(eta_min)
+        self.warmup_steps = max(0, int(warmup_steps))
+        self.warmup_start_lr = float(warmup_start_lr)
+        super().__init__(optimizer, last_epoch)
+
+    def _current_cycle_length(self, step_in_cycle):
+        cycle_length = self.T_0
+        if self.T_mult == 1:
+            if cycle_length <= 0:
+                cycle_length = 1
+            return cycle_length, step_in_cycle % cycle_length
+
+        remaining = step_in_cycle
+        cycle_length = max(1, self.T_0)
+        while remaining >= cycle_length:
+            remaining -= cycle_length
+            cycle_length = max(1, int(cycle_length * self.T_mult))
+        return cycle_length, remaining
+
+    def get_lr(self):
+        step = self.last_epoch
+        if self.warmup_steps > 0 and step < self.warmup_steps:
+            progress = (step + 1) / float(self.warmup_steps)
+            return [
+                self.warmup_start_lr + (base_lr - self.warmup_start_lr) * progress
+                for base_lr in self.base_lrs
+            ]
+
+        step_in_cycle = max(0, step - self.warmup_steps)
+        cycle_length, cycle_progress = self._current_cycle_length(step_in_cycle)
+        cycle_length = max(1, cycle_length)
+        cosine_value = math.cos(math.pi * cycle_progress / float(cycle_length))
+        scale = (1.0 + cosine_value) / 2.0
+        return [
+            self.eta_min + (base_lr - self.eta_min) * scale
+            for base_lr in self.base_lrs
+        ]
+
+
+def build_optimizer(parameters, runtime_params=None):
+    optimizer, scheduler = _define_optimizer(parameters, runtime_params or {})
     return optimizer, scheduler
 
-def _define_optimizer(params):
-    optimizer_params = params['optimizer_params']
-    sch_params = params['scheduler_params']
+def _define_optimizer(params, runtime_params):
+    optimizer_params = params.get('optimizer_params', {}) or {}
+    betas = optimizer_params.get('betas', (0.9, 0.98))
+    if isinstance(betas, (list, tuple)) and len(betas) == 2:
+        betas = tuple(betas)
+    else:
+        betas = (0.9, 0.98)
     optimizer = AdamW(
         params['params'],
         lr=optimizer_params.get('lr', 1e-4),
         weight_decay=optimizer_params.get('weight_decay', 5e-4),
-        betas=(0.9, 0.98),
-        eps=1e-9)
-    scheduler = _define_scheduler(optimizer, sch_params)
+        betas=betas,
+        eps=optimizer_params.get('eps', 1e-9))
+    scheduler = _define_scheduler(optimizer, optimizer_params, runtime_params)
     return optimizer, scheduler
 
-def _define_scheduler(optimizer, params):
-    print(params)
-    max_lr = params.get('max_lr', 5e-4)
-    pct_start = params.get('pct_start', 0.0)
-    final_div_factor = params.get('final_div_factor', 5)
+def _define_scheduler(optimizer, optimizer_params, runtime_params):
+    scheduler_config = optimizer_params.get('scheduler')
+    legacy_pct_start = optimizer_params.get('pct_start')
+    legacy_final_div = optimizer_params.get('final_div_factor', 5.0)
+    if scheduler_config is None and legacy_pct_start is not None:
+        scheduler_config = {
+            'enabled': True,
+            'type': 'one_cycle',
+            'one_cycle': {
+                'pct_start': legacy_pct_start,
+                'final_div_factor': legacy_final_div,
+            },
+        }
 
-    total_steps = params.get('total_steps')
-    if total_steps is not None:
-        scheduler = torch.optim.lr_scheduler.OneCycleLR(
+    if not scheduler_config:
+        return None
+
+    if not scheduler_config.get('enabled', True):
+        return None
+
+    scheduler_type = scheduler_config.get('type', 'one_cycle')
+    max_lr = optimizer_params.get('max_lr', optimizer_params.get('lr', 5e-4))
+
+    if scheduler_type == 'one_cycle':
+        one_cycle_cfg = scheduler_config.get('one_cycle', {}) or {}
+        pct_start = float(one_cycle_cfg.get('pct_start', legacy_pct_start if legacy_pct_start is not None else 0.1))
+        final_div_factor = float(one_cycle_cfg.get('final_div_factor', legacy_final_div))
+        total_steps = one_cycle_cfg.get('total_steps', runtime_params.get('total_steps'))
+        if total_steps is not None:
+            scheduler = torch.optim.lr_scheduler.OneCycleLR(
+                optimizer,
+                max_lr=max_lr,
+                total_steps=int(total_steps),
+                pct_start=pct_start,
+                final_div_factor=final_div_factor,
+            )
+        else:
+            epochs = one_cycle_cfg.get('epochs', runtime_params.get('epochs', 200))
+            steps_per_epoch = one_cycle_cfg.get('steps_per_epoch', runtime_params.get('steps_per_epoch', 1000))
+            scheduler = torch.optim.lr_scheduler.OneCycleLR(
+                optimizer,
+                max_lr=max_lr,
+                epochs=int(epochs),
+                steps_per_epoch=int(steps_per_epoch),
+                pct_start=pct_start,
+                final_div_factor=final_div_factor,
+            )
+        scheduler.total_steps = total_steps if total_steps is not None else int(runtime_params.get('total_steps', 0) or 0)
+        scheduler.scheduler_type = 'one_cycle'
+        scheduler.pct_start = pct_start
+        scheduler.final_div_factor = final_div_factor
+        return scheduler
+
+    if scheduler_type == 'cosine_warm_restarts':
+        cosine_cfg = scheduler_config.get('cosine_warm_restarts', {}) or {}
+        steps_per_epoch = runtime_params.get('steps_per_epoch')
+        T_0_steps = cosine_cfg.get('T_0_steps')
+        if T_0_steps is None:
+            T_0_epochs = cosine_cfg.get('T_0_epochs', 1)
+            if steps_per_epoch is None:
+                raise ValueError(
+                    "`steps_per_epoch` must be provided in runtime_params to derive `T_0_steps` for the cosine warm restart scheduler."
+                )
+            T_0_steps = max(1, int(round(float(T_0_epochs) * steps_per_epoch)))
+        else:
+            T_0_steps = max(1, int(T_0_steps))
+
+        T_mult = int(cosine_cfg.get('T_mult', 1))
+        eta_min = float(cosine_cfg.get('eta_min', 0.0))
+        warmup_pct = cosine_cfg.get('warmup_pct', cosine_cfg.get('pct_start', legacy_pct_start if legacy_pct_start is not None else 0.0))
+        warmup_steps = cosine_cfg.get('warmup_steps')
+        if warmup_steps is None:
+            warmup_steps = int(round(T_0_steps * float(warmup_pct or 0.0)))
+        else:
+            warmup_steps = int(warmup_steps)
+        warmup_start_lr = float(cosine_cfg.get('warmup_start_lr', eta_min))
+
+        scheduler = CosineWarmupRestarts(
             optimizer,
-            max_lr=max_lr,
-            total_steps=int(total_steps),
-            pct_start=pct_start,
-            final_div_factor=final_div_factor,
+            T_0=T_0_steps,
+            T_mult=T_mult,
+            eta_min=eta_min,
+            warmup_steps=warmup_steps,
+            warmup_start_lr=warmup_start_lr,
         )
-    else:
-        scheduler = torch.optim.lr_scheduler.OneCycleLR(
-            optimizer,
-            max_lr=max_lr,
-            epochs=params.get('epochs', 200),
-            steps_per_epoch=params.get('steps_per_epoch', 1000),
-            pct_start=pct_start,
-            final_div_factor=final_div_factor)
+        scheduler.total_steps = runtime_params.get('total_steps')
+        scheduler.scheduler_type = 'cosine_warm_restarts'
+        scheduler.max_lr = max_lr
+        scheduler.T_0 = T_0_steps
+        scheduler.T_mult = T_mult
+        scheduler.eta_min = eta_min
+        scheduler.warmup_steps = warmup_steps
+        scheduler.warmup_start_lr = warmup_start_lr
+        scheduler.warmup_pct = warmup_pct
+        return scheduler
 
-    return scheduler
+    raise ValueError(f"Unsupported scheduler type: {scheduler_type}")
 
-def build_multi_optimizer(parameters_dict, scheduler_params):
-    optim = dict([(key, AdamW(params, lr=1e-4, weight_decay=1e-6, betas=(0.9, 0.98), eps=1e-9))
-                   for key, params in parameters_dict.items()])
+def build_multi_optimizer(parameters_dict, optimizer_params, runtime_params=None):
+    runtime_params = runtime_params or {}
+    optim = dict([
+        (
+            key,
+            AdamW(
+                params,
+                lr=optimizer_params.get('lr', 1e-4),
+                weight_decay=optimizer_params.get('weight_decay', 1e-6),
+                betas=tuple(optimizer_params.get('betas', (0.9, 0.98))),
+                eps=optimizer_params.get('eps', 1e-9),
+            ),
+        )
+        for key, params in parameters_dict.items()
+    ])
 
-    schedulers = dict([(key, _define_scheduler(opt, scheduler_params)) \
-                       for key, opt in optim.items()])
+    schedulers = dict([
+        (key, _define_scheduler(opt, optimizer_params, runtime_params))
+        for key, opt in optim.items()
+    ])
 
     multi_optim = MultiOptimizer(optim, schedulers)
     return multi_optim

--- a/train.py
+++ b/train.py
@@ -372,20 +372,86 @@ def main(config_path):
     model = build_model(model_params=model_params)
 
     total_training_steps = batch_scheduler.expected_total_steps(num_train_items)
-    scheduler_params = {
-            'max_lr': float(cfg_get_nested( config, 'optimizer_params.lr', 5e-4)),
-            'pct_start': float(cfg_get_nested( config, 'optimizer_params.pct_start', 0.1)),
-            'epochs': epochs,
-            'steps_per_epoch': steps_per_epoch,
-            'total_steps': total_training_steps,
+
+    optimizer_config = dict(cfg_get_nested(config, 'optimizer_params', {}) or {})
+    scheduler_config = optimizer_config.get('scheduler')
+    if scheduler_config is None and 'pct_start' in optimizer_config:
+        scheduler_config = {
+            'enabled': True,
+            'type': 'one_cycle',
+            'one_cycle': {
+                'pct_start': optimizer_config.get('pct_start'),
+                'final_div_factor': optimizer_config.get('final_div_factor', 5.0),
+            },
         }
-    config['scheduler_params'] = scheduler_params
+        optimizer_config['scheduler'] = scheduler_config
+    scheduler_config = scheduler_config or {}
+    scheduler_enabled = bool(scheduler_config.get('enabled', True))
+    scheduler_type = scheduler_config.get('type', 'one_cycle')
+
+    scheduler_runtime_params = {
+        'epochs': epochs,
+        'steps_per_epoch': steps_per_epoch,
+        'total_steps': total_training_steps,
+    }
+
+    max_lr = float(optimizer_config.get('max_lr', optimizer_config.get('lr', 5e-4)))
+    scheduler_metadata = {
+        'enabled': scheduler_enabled,
+        'type': scheduler_type,
+        'max_lr': max_lr,
+    }
+
+    if scheduler_enabled:
+        if scheduler_type == 'one_cycle':
+            one_cycle_cfg = scheduler_config.get('one_cycle', {}) or {}
+            pct_start = float(one_cycle_cfg.get('pct_start', optimizer_config.get('pct_start', 0.1)))
+            final_div_factor = float(one_cycle_cfg.get('final_div_factor', optimizer_config.get('final_div_factor', 5.0)))
+            total_steps_override = one_cycle_cfg.get('total_steps')
+            steps_override = one_cycle_cfg.get('steps_per_epoch')
+            epochs_override = one_cycle_cfg.get('epochs')
+            scheduler_metadata.update({
+                'pct_start': pct_start,
+                'final_div_factor': final_div_factor,
+                'total_steps': int(total_steps_override if total_steps_override is not None else total_training_steps),
+                'steps_per_epoch': int(steps_override if steps_override is not None else steps_per_epoch),
+                'epochs': int(epochs_override if epochs_override is not None else epochs),
+            })
+        elif scheduler_type == 'cosine_warm_restarts':
+            cosine_cfg = scheduler_config.get('cosine_warm_restarts', {}) or {}
+            T_0_steps = cosine_cfg.get('T_0_steps')
+            if T_0_steps is None:
+                T_0_epochs = cosine_cfg.get('T_0_epochs', 1)
+                T_0_steps = max(1, int(round(float(T_0_epochs) * steps_per_epoch)))
+            else:
+                T_0_steps = max(1, int(T_0_steps))
+            T_mult = int(cosine_cfg.get('T_mult', 1))
+            eta_min = float(cosine_cfg.get('eta_min', 0.0))
+            warmup_pct = float(cosine_cfg.get('warmup_pct', cosine_cfg.get('pct_start', optimizer_config.get('pct_start', 0.0))))
+            warmup_steps = cosine_cfg.get('warmup_steps')
+            if warmup_steps is None:
+                warmup_steps = int(round(T_0_steps * warmup_pct))
+            else:
+                warmup_steps = int(warmup_steps)
+            warmup_start_lr = float(cosine_cfg.get('warmup_start_lr', eta_min))
+            scheduler_metadata.update({
+                'T_0': T_0_steps,
+                'T_mult': T_mult,
+                'eta_min': eta_min,
+                'warmup_steps': warmup_steps,
+                'warmup_start_lr': warmup_start_lr,
+                'pct_start': warmup_pct,
+            })
+
+    config['scheduler_params'] = scheduler_metadata
 
     entropy_params = cfg_get_nested( config, 'entropy_params', { "label_smoothing": 0.1 })
 
     model.to(device)
     optimizer, scheduler = build_optimizer(
-        {"params": model.parameters(), "optimizer_params":{}, "scheduler_params": scheduler_params})
+        {"params": model.parameters(), "optimizer_params": optimizer_config},
+        runtime_params=scheduler_runtime_params,
+    )
 
     blank_index = sorted_train_dataloader.dataset.text_cleaner.word_index_dictionary[" "] # get blank index
     criterion = build_criterion(critic_params={

--- a/trainer.py
+++ b/trainer.py
@@ -483,7 +483,7 @@ class Trainer(object):
         """
         state_dict = {
             "optimizer": self.optimizer.state_dict(),
-            "scheduler": self.scheduler.state_dict(),
+            "scheduler": self.scheduler.state_dict() if self.scheduler is not None else {},
             "steps": self.steps,
             "epochs": self.epochs,
         }
@@ -512,8 +512,10 @@ class Trainer(object):
             self.logger.info("Starting training from epoch %i" % state_dict["epochs"])
 
             # overwrite schedular argument parameters
-            state_dict["scheduler"].update(**self.config.get("scheduler_params", {}))
-            self.scheduler.load_state_dict(state_dict["scheduler"])
+            scheduler_state = state_dict.get("scheduler", {})
+            scheduler_state.update(**self.config.get("scheduler_params", {}))
+            if self.scheduler is not None:
+                self.scheduler.load_state_dict(scheduler_state)
 
         self._optimizer_step_count = self._get_optimizer_step_count()
 


### PR DESCRIPTION
## Summary
- add config-driven scheduler options supporting OneCycle and cosine warm restarts
- extend optimizer utilities and trainer handling to support the new schedulers
- document scheduler toggles in the README and Utils notebooks

## Testing
- python -m compileall train.py optimizers.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68d9036988b08332b0e95b1eaed6b053