### PR TITLE
Enable lazy shared phoneme dictionary loading

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -10,6 +10,16 @@ val_data: "Data/val_list.txt"
 ood_data: "Data/OOD_texts.txt"
 phoneme_maps_path: "Data/word_index_dict.txt"
 
+# Control how phoneme dictionaries are loaded.  When lazy loading is enabled the
+# CSV file is only parsed the first time a worker needs the mapping.  The shared
+# cache reuses the parsed dictionary across dataloader workers via a
+# multiprocessing manager so that each process avoids re-reading the CSV.
+phoneme_dictionary:
+  lazy_loading:
+    enabled: true  # Set to false to parse the dictionary immediately during dataset initialisation.
+  shared_cache:
+    enabled: true  # Disable to fall back to per-process caching without cross-worker sharing.
+
 # Controls caching of parsed metadata entries and audio durations.  Enabling this
 # significantly reduces start-up time by avoiding repeated WAV header scans.
 metadata_cache:

--- a/Utils/AuxiliaryASR_CTC_Entropy.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Entropy.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "66cea252",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3e059041",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,15 +377,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_CTC_Loss.ipynb
+++ b/Utils/AuxiliaryASR_CTC_Loss.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6fb362bf",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "0436c4cc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,15 +379,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
+++ b/Utils/AuxiliaryASR_Diagonal_Attention.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "511037db",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "cf9280aa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,9 +119,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e158ac40",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -135,6 +143,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "50c5bd8a",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -206,15 +215,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",
@@ -438,6 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "406d4fef",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/Utils/AuxiliaryASR_Duration_Stats.ipynb
+++ b/Utils/AuxiliaryASR_Duration_Stats.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "5ae4141b",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d4145313",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,15 +376,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_Noise_Robustness.ipynb
+++ b/Utils/AuxiliaryASR_Noise_Robustness.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "3f165d07",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d3e63184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,15 +368,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_PER_Eval.ipynb
+++ b/Utils/AuxiliaryASR_PER_Eval.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "6c30bc4c",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "dc9f4a93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,15 +374,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
+++ b/Utils/AuxiliaryASR_SkipMergeFlags.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "030157ef",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "977e6cfd",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,15 +360,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",

--- a/Utils/AuxiliaryASR_Visual_Check.ipynb
+++ b/Utils/AuxiliaryASR_Visual_Check.ipynb
@@ -8,12 +8,17 @@
     "## Multi-task auxiliary objectives update\n",
     "This notebook has been updated to work with the extended multi-task ASR head. You can enable or disable CTC, seq2seq, frame-level phoneme classifiers, speaker embeddings, and pronunciation error classifiers individually through `Configs/config.yml` under the `multi_task` section. Adjust the corresponding `loss_weights` entries when experimenting with these objectives.\n",
     "\n",
-    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training."
+    "> **Entropy regularisation**: Use the new `regularization.entropy` section in `Configs/config.yml` to enable or disable per-head entropy penalties. You can independently attach the regulariser to the CTC and seq2seq objectives without breaking joint training.\n",
+    "\n",
+    "> **Lazy phoneme dictionaries**: Toggle `phoneme_dictionary.lazy_loading` and `phoneme_dictionary.shared_cache` in `Configs/config.yml` to control when the phoneme map is parsed and whether dataloader workers reuse the cached mapping."
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "50453a8a",
    "metadata": {},
+   "outputs": [],
    "source": [
     "# Inspect and optionally warm the metadata cache for notebook experiments\n",
     "import os\n",
@@ -92,13 +97,12 @@
     "        print(f\"[cache] OOD entries available: {len(_ood_entries)}\")\n",
     "    except FileNotFoundError:\n",
     "        print(f\"[cache] OOD metadata not found at {_ood_metadata_path!r}\")\n"
-   ],
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "59b96dc6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,9 +119,13 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1f6ad80a",
    "metadata": {},
    "source": [
-    "## Memory optimization settings\nLazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n\nGradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
+    "## Memory optimization settings\n",
+    "Lazy creation of decoder masks can now be toggled through the new `memory_optimizations.lazy_masks` section in `Configs/config.yml`. When enabled (the default), the trainer skips preallocating the `future_mask` and `text_mask` tensors unless an experiment explicitly needs them. Set the corresponding flags to `false` to restore the previous eager allocation behaviour.\n",
+    "\n",
+    "Gradient checkpointing for the deeper encoder blocks is configurable through `memory_optimizations.gradient_checkpointing`. Setting `enabled: true` activates `torch.utils.checkpoint.checkpoint_sequential` on the selected layer range so activations are recomputed during backpropagation instead of stored. Tune `start_layer`/`end_layer` to target specific encoder depths, `chunk_size` to limit how many stages are bundled into a checkpoint, and `segments` when you need finer control over how each chunk is split. The helper flags `min_sequence_length` and `use_checkpoint_sequential` let you skip short utterances or fall back to the basic checkpoint API if required.\n",
     "\n",
     "### CTC/seq2seq head sharing\n",
     "Enable `multi_task.head_sharing.ctc_seq2seq.enabled` in `Configs/config.yml` to reuse the intermediate projection computed for the CTC logits when running the seq2seq decoder. With the feature turned on the encoder exposes the shared tensor via `model_outputs[\"ctc_seq2seq_shared_states\"]` and feeds an adapter into the decoder so both heads reuse the same computation.\n",
@@ -151,6 +159,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "87948fd8",
    "metadata": {},
    "source": [
     "## Augmentation configuration\n",
@@ -289,6 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "9143f933",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,15 +318,16 @@
     "        ),\n",
     "    }\n",
     "    dataset_params['mel_cache'] = cfg_get_nested(config, 'mel_cache', {}) or {}\n",
+    "    dataset_params['phoneme_dictionary_config'] = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}\n",
     "    dataset_overrides = cfg_get_nested(config, 'dataset_params', {})\n",
     "    if isinstance(dataset_overrides, dict):\n",
-    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params'):\n",
+    "        for key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):\n",
     "            if key in dataset_overrides:\n",
     "                dataset_params[key] = dataset_overrides[key]\n",
     "        if 'spec_augment' in dataset_overrides:\n",
     "            dataset_params['spec_augment_params'] = dataset_overrides['spec_augment']\n",
     "        for key, value in dataset_overrides.items():\n",
-    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'spec_augment'):\n",
+    "            if key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config', 'spec_augment'):\n",
     "                continue\n",
     "            dataset_params[key] = value\n",
     "    if base_overrides:\n",
@@ -679,6 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "785837e3",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/meldataset.py
+++ b/meldataset.py
@@ -762,6 +762,7 @@ class MelDataset(torch.utils.data.Dataset):
     def __init__(self,
                  data_list,
                  dict_path=DEFAULT_DICT_PATH,
+                 dictionary_config=None,
                  sr=24000,
                  spect_params={
                      "n_fft": 2048,
@@ -781,7 +782,7 @@ class MelDataset(torch.utils.data.Dataset):
                 ):
 
         self.data_list = data_list
-        self.text_cleaner = TextCleaner(dict_path)
+        self.text_cleaner = TextCleaner(dict_path, dictionary_config=dictionary_config)
         self.sr = sr
         self.validation = bool(validation)
         if dataset_name is None:
@@ -1074,11 +1075,14 @@ def build_dataloader(path_list,
 
     dataset_cfg = dict(dataset_config or {})
     mel_cache_cfg = dataset_cfg.pop('mel_cache', None)
+    phoneme_dict_cfg = dataset_cfg.pop('phoneme_dictionary_config', None)
+
     dataset = MelDataset(
         path_list,
         validation=validation,
         mel_cache=mel_cache_cfg,
         dataset_name=dataset_name,
+        dictionary_config=phoneme_dict_cfg,
         **dataset_cfg,
     )
     collate_fn = Collater(**collate_config)

--- a/phoneme_dictionary.py
+++ b/phoneme_dictionary.py
@@ -1,0 +1,183 @@
+"""Utilities for loading and sharing phoneme dictionaries across workers.
+
+This module centralises the logic for parsing phoneme-to-index dictionaries and
+optionally sharing the parsed mapping between dataloader workers.  The primary
+entry point is :func:`load_phoneme_dictionary`, which accepts a path or mapping
+and returns a standard Python ``dict`` instance.
+
+The loader honours configuration flags that control lazy loading and
+cross-process sharing.  When sharing is enabled the first process that touches a
+dictionary parses it and stores the result inside a ``multiprocessing.Manager``
+dictionary.  Subsequent workers simply copy the cached mapping instead of
+re-parsing the CSV file.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import os
+import threading
+from typing import Dict, Mapping, MutableMapping, Optional, Tuple, Union
+
+import pandas as pd
+
+LOGGER = logging.getLogger(__name__)
+
+
+# Local in-process cache keyed by the absolute path of the dictionary file.
+_LOCAL_CACHE: Dict[str, Dict[str, int]] = {}
+_LOCAL_LOCK = threading.RLock()
+
+
+class _SharedState:
+    """Encapsulates the multiprocessing manager used for cross-worker sharing."""
+
+    __slots__ = ("manager", "cache", "lock")
+
+    def __init__(self, manager: mp.Manager, cache: MutableMapping[str, Dict[str, int]], lock: mp.RLock):
+        self.manager = manager
+        self.cache = cache
+        self.lock = lock
+
+
+_SHARED_STATE: Optional[_SharedState] = None
+_SHARED_STATE_LOCK = threading.Lock()
+
+
+def _get_shared_state() -> Optional[_SharedState]:
+    """Initialise or return the shared multiprocessing cache.
+
+    On some environments (for example, restricted sandboxes) spawning a
+    ``multiprocessing.Manager`` can fail.  In that case we silently disable
+    cross-worker sharing and fall back to the process-local cache.
+    """
+
+    global _SHARED_STATE
+    if _SHARED_STATE is not None:
+        return _SHARED_STATE
+
+    with _SHARED_STATE_LOCK:
+        if _SHARED_STATE is not None:
+            return _SHARED_STATE
+        try:
+            manager = mp.Manager()
+            cache = manager.dict()  # type: ignore[assignment]
+            lock = manager.RLock()  # type: ignore[assignment]
+        except (OSError, ValueError) as exc:
+            LOGGER.warning(
+                "Failed to initialise multiprocessing manager for phoneme dictionary sharing: %s. "
+                "Falling back to process-local caching only.",
+                exc,
+            )
+            return None
+
+        _SHARED_STATE = _SharedState(manager=manager, cache=cache, lock=lock)
+        return _SHARED_STATE
+
+
+def _load_dictionary_from_disk(path: str) -> Dict[str, int]:
+    """Parse a phoneme dictionary CSV into a mapping.
+
+    Args:
+        path: Path to the CSV file containing ``phoneme,index`` pairs.
+
+    Returns:
+        A dictionary mapping phoneme symbols to integer ids.
+    """
+
+    csv = pd.read_csv(path, header=None).values
+    dictionary: Dict[str, int] = {}
+    for word, index in csv:
+        dictionary[str(word)] = int(index)
+    return dictionary
+
+
+def _resolve_config(config: Optional[Mapping]) -> Tuple[bool, bool]:
+    """Return the resolved (lazy_enabled, share_enabled) flags."""
+
+    if not isinstance(config, Mapping):
+        return True, True
+
+    lazy_cfg = config.get("lazy_loading", {}) if isinstance(config.get("lazy_loading"), Mapping) else config.get("lazy_loading")
+    share_cfg = config.get("shared_cache", {}) if isinstance(config.get("shared_cache"), Mapping) else config.get("shared_cache")
+
+    lazy_enabled = True
+    share_enabled = True
+
+    if isinstance(lazy_cfg, Mapping):
+        lazy_enabled = bool(lazy_cfg.get("enabled", True))
+    elif isinstance(lazy_cfg, bool):
+        lazy_enabled = lazy_cfg
+
+    if isinstance(share_cfg, Mapping):
+        share_enabled = bool(share_cfg.get("enabled", True))
+    elif isinstance(share_cfg, bool):
+        share_enabled = share_cfg
+
+    return lazy_enabled, share_enabled
+
+
+def load_phoneme_dictionary(
+    path_or_mapping: Union[str, Mapping[str, int]],
+    config: Optional[Mapping] = None,
+) -> Dict[str, int]:
+    """Return a phoneme dictionary.
+
+    The function accepts either a file path or an in-memory mapping.  When a
+    path is provided, the loading behaviour is controlled by ``config``:
+
+    * ``lazy_loading.enabled`` (default ``True``) keeps the parsed dictionary in
+      memory so it is reused within the process.
+    * ``shared_cache.enabled`` (default ``True``) stores the parsed dictionary in
+      a ``multiprocessing.Manager`` dictionary to avoid re-parsing in dataloader
+      workers spawned from other processes.
+    """
+
+    if isinstance(path_or_mapping, Mapping):
+        return dict(path_or_mapping)
+
+    path = os.path.abspath(str(path_or_mapping))
+    lazy_enabled, share_enabled = _resolve_config(config)
+
+    if not lazy_enabled:
+        dictionary = _load_dictionary_from_disk(path)
+        if share_enabled:
+            shared_state = _get_shared_state()
+            if shared_state is not None:
+                with shared_state.lock:
+                    shared_state.cache[path] = dictionary
+        return dictionary
+
+    with _LOCAL_LOCK:
+        cached = _LOCAL_CACHE.get(path)
+        if cached is not None:
+            return cached
+
+    if share_enabled:
+        shared_state = _get_shared_state()
+        if shared_state is not None:
+            cache = shared_state.cache
+            # Fast path: if another worker already cached the dictionary we can reuse it.
+            if path in cache:
+                dictionary = dict(cache[path])
+                with _LOCAL_LOCK:
+                    _LOCAL_CACHE[path] = dictionary
+                return dictionary
+            # Slow path: take the shared lock, double-check, and populate the cache.
+            with shared_state.lock:
+                if path not in cache:
+                    cache[path] = _load_dictionary_from_disk(path)
+                dictionary = dict(cache[path])
+            with _LOCAL_LOCK:
+                _LOCAL_CACHE[path] = dictionary
+            return dictionary
+
+    dictionary = _load_dictionary_from_disk(path)
+    with _LOCAL_LOCK:
+        _LOCAL_CACHE[path] = dictionary
+    return dictionary
+
+
+__all__ = ["load_phoneme_dictionary"]
+

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,10 +1,13 @@
 import os
-import pandas as pd
+from typing import Mapping, Optional
+
+from phoneme_dictionary import load_phoneme_dictionary
 
 DEFAULT_DICT_PATH = os.path.join('word_index_dict.txt')
 
+
 class TextCleaner:
-    def __init__(self, word_index_dict_path=DEFAULT_DICT_PATH):
+    def __init__(self, word_index_dict_path=DEFAULT_DICT_PATH, dictionary_config: Optional[Mapping] = None):
         """Create a TextCleaner.
 
         Parameters
@@ -12,11 +15,32 @@ class TextCleaner:
         word_index_dict_path : str or dict
             Either a path to a CSV file mapping phonemes to indices or a
             dictionary object already containing the mapping.
+        dictionary_config : mapping, optional
+            Behaviour overrides for lazy loading and cross-worker sharing.  See
+            :func:`phoneme_dictionary.load_phoneme_dictionary` for the supported
+            keys.
         """
-        self.word_index_dictionary = self.load_dictionary(word_index_dict_path)
-        # mapping from index back to symbol
-        self.inverse_mapping = {index: word for word, index in self.word_index_dictionary.items()}
-        #print(word_index_dict_path, len(self.word_index_dictionary))
+        self._dictionary_config = dictionary_config
+        self._dictionary_source = word_index_dict_path
+        self._word_index_dictionary = None
+        self._inverse_mapping = None
+
+        if isinstance(word_index_dict_path, dict):
+            self._word_index_dictionary = dict(word_index_dict_path)
+        else:
+            lazy_enabled = True
+            if isinstance(dictionary_config, Mapping):
+                lazy_section = dictionary_config.get('lazy_loading')
+                if isinstance(lazy_section, Mapping):
+                    lazy_enabled = bool(lazy_section.get('enabled', True))
+                elif isinstance(lazy_section, bool):
+                    lazy_enabled = lazy_section
+
+            if not lazy_enabled:
+                self._word_index_dictionary = self.load_dictionary(word_index_dict_path)
+
+        if self._word_index_dictionary is not None:
+            self._inverse_mapping = {index: word for word, index in self._word_index_dictionary.items()}
 
     def __call__(self, text):
         indexes = []
@@ -27,11 +51,26 @@ class TextCleaner:
                 print(f"(TextCleaner) Warning: Phoneme '{char}' not found in dictionary. Text: " + "".join(text))
         return indexes
 
+    @property
+    def word_index_dictionary(self):
+        self._ensure_dictionary_loaded()
+        return self._word_index_dictionary
+
+    @property
+    def inverse_mapping(self):
+        self._ensure_dictionary_loaded()
+        if self._inverse_mapping is None and self._word_index_dictionary is not None:
+            self._inverse_mapping = {index: word for word, index in self._word_index_dictionary.items()}
+        return self._inverse_mapping
+
+    def _ensure_dictionary_loaded(self):
+        if self._word_index_dictionary is None:
+            self._word_index_dictionary = self.load_dictionary(self._dictionary_source)
+            self._inverse_mapping = {index: word for word, index in self._word_index_dictionary.items()}
+
     def load_dictionary(self, path_or_dict):
         """Load phoneme to index mapping from a path or return the given dict."""
         if isinstance(path_or_dict, dict):
-            return path_or_dict
+            return dict(path_or_dict)
 
-        csv = pd.read_csv(path_or_dict, header=None).values
-        word_index_dict = {word: index for word, index in csv}
-        return word_index_dict
+        return load_phoneme_dictionary(path_or_dict, config=self._dictionary_config)

--- a/train.py
+++ b/train.py
@@ -505,12 +505,15 @@ def main(config_path):
         'mel_params': cfg_get_nested( config, 'preprocess_params.mel_params', { 'n_mels': 80 })
     }
 
+    phoneme_dict_config = cfg_get_nested(config, 'phoneme_dictionary', {}) or {}
+    dataset_params['phoneme_dictionary_config'] = phoneme_dict_config
+
     mel_cache_config = cfg_get_nested(config, 'mel_cache', {}) or {}
     dataset_params['mel_cache'] = mel_cache_config
 
     dataset_additional_params = cfg_get_nested(config, 'dataset_params', {})
     if isinstance(dataset_additional_params, dict):
-        for override_key in ('dict_path', 'sr', 'spect_params', 'mel_params'):
+        for override_key in ('dict_path', 'sr', 'spect_params', 'mel_params', 'phoneme_dictionary_config'):
             if override_key in dataset_additional_params:
                 dataset_params[override_key] = dataset_additional_params[override_key]
 


### PR DESCRIPTION
## Summary
- add a phoneme dictionary cache that lazily loads CSV mappings and optionally shares them across dataloader workers
- update TextCleaner, the dataset builder, and the main training script to honour the new phoneme dictionary configuration flags
- document and surface the new toggles in `Configs/config.yml` and ensure every utility notebook loads the updated dataset parameters

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68da3af97ed8833292142a426a63855f