### PR TITLE
Add Accelerate FSDP support

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -16,7 +16,7 @@ distributed:
     cpu_offload:
       enabled: false
       offload_params: true
-      pin_memory: false
+      pin_memory: false  # Ignored when the installed torch build lacks CPUOffload pin_memory support.
     mixed_precision:
       param_dtype: null
       reduce_dtype: null

--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -1,6 +1,35 @@
 log_dir: "Checkpoint"
 save_freq: 10
 device: "cuda"
+distributed:
+  fsdp:
+    enabled: false
+    # Available options: FULL_SHARD, SHARD_GRAD_OP, NO_SHARD, HYBRID_SHARD
+    sharding_strategy: full_shard
+    # Options: BACKWARD_POST, BACKWARD_PRE
+    backward_prefetch: backward_post
+    # Options: FULL_STATE_DICT, LOCAL_STATE_DICT, SHARDED_STATE_DICT
+    state_dict_type: full_state_dict
+    limit_all_gathers: true
+    use_orig_params: false
+    forward_prefetch: true
+    cpu_offload:
+      enabled: false
+      offload_params: true
+      pin_memory: false
+    mixed_precision:
+      param_dtype: null
+      reduce_dtype: null
+      buffer_dtype: null
+    auto_wrap_policy:
+      enabled: false
+      min_num_params: 100000000
+    activation_checkpointing:
+      enabled: false
+      config: null
+  ddp:
+    find_unused_parameters: true
+    broadcast_buffers: true
 epochs: 200
 batch_size: 64
 pretrained_model: true

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ The script automatically handles distributed setup, device placement and metric 
 The `batch_size` defined in `Configs/config.yml` represents the desired *global* batch size. When training across multiple GPUs
 the launcher will automatically downscale the per-device batch size and keep the learning-rate scheduler in sync so that the
 effective global batch matches the single-GPU configuration.
+
+### Fully Sharded Data Parallel
+
+Training very large models can be memory bound even when using several GPUs. AuxiliaryASR now supports
+[Fully Sharded Data Parallel](https://pytorch.org/docs/stable/fsdp.html) via 🤗 Accelerate. Enable it in your configuration by
+setting `distributed.fsdp.enabled: true`:
+
+```yaml
+distributed:
+  fsdp:
+    enabled: true
+    sharding_strategy: full_shard
+    mixed_precision:
+      param_dtype: float16
+      reduce_dtype: float16
+      buffer_dtype: float16
+```
+
+You can further customise sharding, state-dict handling, CPU offloading and auto-wrap behaviour through the rest of the
+`distributed.fsdp` block in `Configs/config.yml`. The trainer will automatically construct the appropriate Accelerate plugin and
+use `accelerator.get_state_dict` when saving checkpoints so that consolidated weights are written from FSDP shards. Launch the
+script with `accelerate launch` to run across multiple GPUs.
+
 Please specify the training and validation data in `config.yml` file. The data list format needs to be `filename.wav|label-in-espeak-phonemes|speaker_number`, see [train_list.txt](https://github.com/martinambrus/AuxiliaryASR/blob/main/Data/train_list.txt) as an example (a custom sample of phonemized WAV files used for English training). Note that `speaker_number` can just be `0` for ASR, but it is useful to set a meaningful number for TTS training in StyleTTS2.
 
 Checkpoints and Tensorboard logs will be saved at `log_dir`. To speed up training, you may want to make `batch_size` as large as your GPU RAM can take - but not beyond 64, as anything beyond this value did not yield desired results in my testing. Please note that `batch_size = 64` will take around 10G GPU RAM.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ distributed:
 ```
 
 You can further customise sharding, state-dict handling, CPU offloading and auto-wrap behaviour through the rest of the
-`distributed.fsdp` block in `Configs/config.yml`. The trainer will automatically construct the appropriate Accelerate plugin and
+`distributed.fsdp` block in `Configs/config.yml`. When requesting CPU offload pinning keep in mind that older PyTorch builds do
+not expose the `pin_memory` flag on `CPUOffload`; the trainer will automatically ignore the option and emit a warning in that
+case. The trainer will automatically construct the appropriate Accelerate plugin and
 use `accelerator.get_state_dict` when saving checkpoints so that consolidated weights are written from FSDP shards. Launch the
 script with `accelerate launch` to run across multiple GPUs.
 

--- a/train.py
+++ b/train.py
@@ -5,6 +5,7 @@ from models import build_model
 from trainer import Trainer
 
 import copy
+import inspect
 import os
 import os.path as osp
 import math
@@ -192,11 +193,18 @@ def _build_fsdp_plugin(fsdp_config, device_hint=None):
     cpu_offload_cfg = fsdp_config.get("cpu_offload", False)
     cpu_offload = None
     if isinstance(cpu_offload_cfg, dict):
-        offload_params = bool(cpu_offload_cfg.get("offload_params", True))
-        cpu_offload = CPUOffload(
-            offload_params=offload_params,
-            pin_memory=bool(cpu_offload_cfg.get("pin_memory", False)),
-        )
+        if cpu_offload_cfg.get("enabled", True):
+            offload_params = bool(cpu_offload_cfg.get("offload_params", True))
+            cpu_offload_kwargs = {"offload_params": offload_params}
+            if cpu_offload_cfg.get("pin_memory"):
+                signature = inspect.signature(CPUOffload)
+                if "pin_memory" in signature.parameters:
+                    cpu_offload_kwargs["pin_memory"] = True
+                else:
+                    warnings.append(
+                        "CPU offload pin_memory requested but not supported by this torch build; ignoring the flag."
+                    )
+            cpu_offload = CPUOffload(**cpu_offload_kwargs)
     elif cpu_offload_cfg:
         cpu_offload = CPUOffload(offload_params=True)
     if cpu_offload is not None:

--- a/train.py
+++ b/train.py
@@ -24,6 +24,10 @@ import importlib.util
 from pathlib import Path
 from accelerate import Accelerator
 from accelerate.utils import DistributedDataParallelKwargs
+try:
+    from accelerate.utils import FullyShardedDataParallelPlugin
+except ImportError:  # pragma: no cover - older accelerate versions
+    FullyShardedDataParallelPlugin = None
 
 # enable better memory management
 os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
@@ -60,6 +64,193 @@ _OPTIONAL_TQDM = _load_optional_tqdm()
 
 
 _METADATA_CACHE_VERSION = 2
+
+
+def _normalise_choice(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value
+    else:
+        text = str(value)
+    return text.strip().replace("-", "_").replace(" ", "_").upper()
+
+
+def _enum_member_from_config(enum_cls, value, config_key, warnings):
+    if value is None:
+        return None
+    if isinstance(value, enum_cls):
+        return value
+    if isinstance(value, str):
+        normalised = _normalise_choice(value)
+        for member in enum_cls:
+            if member.name == normalised:
+                return member
+        warnings.append(
+            f"Unrecognised value '{value}' for {config_key}; falling back to the default."
+        )
+        return None
+    warnings.append(
+        f"Unsupported type {type(value).__name__} for {config_key}; falling back to the default."
+    )
+    return None
+
+
+def _dtype_from_config(value, config_key, warnings):
+    if value is None:
+        return None
+    dtype_map = {
+        "float16": torch.float16,
+        "half": torch.float16,
+        "fp16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "bf16": torch.bfloat16,
+        "float32": torch.float32,
+        "fp32": torch.float32,
+        "float64": torch.float64,
+        "fp64": torch.float64,
+    }
+    key = str(value).strip().lower()
+    if key in dtype_map:
+        return dtype_map[key]
+    warnings.append(
+        f"Unrecognised dtype '{value}' for {config_key}; falling back to the default."
+    )
+    return None
+
+
+def _build_fsdp_plugin(fsdp_config, device_hint=None):
+    if not isinstance(fsdp_config, dict) or not fsdp_config.get("enabled", False):
+        return None, []
+
+    if FullyShardedDataParallelPlugin is None:
+        raise RuntimeError(
+            "FSDP support requires accelerate >= 0.17.0 with FullyShardedDataParallelPlugin available."
+        )
+
+    if device_hint is not None and str(device_hint).lower().startswith("cpu"):
+        raise RuntimeError(
+            "Fully Sharded Data Parallel currently requires CUDA devices; please set device to 'cuda'."
+        )
+
+    try:
+        from torch.distributed.fsdp import (
+            BackwardPrefetch,
+            CPUOffload,
+            MixedPrecision,
+            ShardingStrategy,
+            StateDictType,
+        )
+        from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy
+    except ImportError as exc:  # pragma: no cover - depends on torch build
+        raise RuntimeError(
+            "FSDP was requested but torch.distributed.fsdp is unavailable in this PyTorch build."
+        ) from exc
+
+    warnings = []
+    plugin_kwargs = {}
+
+    sharding_strategy = _enum_member_from_config(
+        ShardingStrategy,
+        fsdp_config.get("sharding_strategy"),
+        "distributed.fsdp.sharding_strategy",
+        warnings,
+    )
+    if sharding_strategy is not None:
+        plugin_kwargs["sharding_strategy"] = sharding_strategy
+
+    backward_prefetch = _enum_member_from_config(
+        BackwardPrefetch,
+        fsdp_config.get("backward_prefetch"),
+        "distributed.fsdp.backward_prefetch",
+        warnings,
+    )
+    if backward_prefetch is not None:
+        plugin_kwargs["backward_prefetch"] = backward_prefetch
+
+    state_dict_type = _enum_member_from_config(
+        StateDictType,
+        fsdp_config.get("state_dict_type"),
+        "distributed.fsdp.state_dict_type",
+        warnings,
+    )
+    if state_dict_type is not None:
+        plugin_kwargs["state_dict_type"] = state_dict_type
+
+    if "limit_all_gathers" in fsdp_config:
+        plugin_kwargs["limit_all_gathers"] = bool(fsdp_config.get("limit_all_gathers"))
+
+    if "use_orig_params" in fsdp_config:
+        plugin_kwargs["use_orig_params"] = bool(fsdp_config.get("use_orig_params"))
+
+    if "forward_prefetch" in fsdp_config:
+        plugin_kwargs["forward_prefetch"] = bool(fsdp_config.get("forward_prefetch"))
+
+    if "sync_module_states" in fsdp_config:
+        plugin_kwargs["sync_module_states"] = bool(fsdp_config.get("sync_module_states"))
+
+    cpu_offload_cfg = fsdp_config.get("cpu_offload", False)
+    cpu_offload = None
+    if isinstance(cpu_offload_cfg, dict):
+        offload_params = bool(cpu_offload_cfg.get("offload_params", True))
+        cpu_offload = CPUOffload(
+            offload_params=offload_params,
+            pin_memory=bool(cpu_offload_cfg.get("pin_memory", False)),
+        )
+    elif cpu_offload_cfg:
+        cpu_offload = CPUOffload(offload_params=True)
+    if cpu_offload is not None:
+        plugin_kwargs["cpu_offload"] = cpu_offload
+
+    mixed_precision_cfg = fsdp_config.get("mixed_precision")
+    if isinstance(mixed_precision_cfg, dict) and mixed_precision_cfg:
+        mp_kwargs = {}
+        for key in ("param_dtype", "reduce_dtype", "buffer_dtype"):
+            dtype = _dtype_from_config(
+                mixed_precision_cfg.get(key),
+                f"distributed.fsdp.mixed_precision.{key}",
+                warnings,
+            )
+            if dtype is not None:
+                mp_kwargs[key] = dtype
+        if mp_kwargs:
+            plugin_kwargs["mixed_precision_policy"] = MixedPrecision(**mp_kwargs)
+
+    auto_wrap_cfg = fsdp_config.get("auto_wrap_policy")
+    if isinstance(auto_wrap_cfg, dict) and auto_wrap_cfg:
+        enabled = auto_wrap_cfg.get("enabled", True)
+        if enabled:
+            policy_type = auto_wrap_cfg.get("type")
+            normalised_type = _normalise_choice(policy_type)
+            if normalised_type in (None, "SIZE_BASED"):
+                min_params = auto_wrap_cfg.get("min_num_params")
+                if min_params is None:
+                    min_params = auto_wrap_cfg.get("min_params")
+                if min_params is not None:
+                    try:
+                        min_params_value = int(min_params)
+                    except (TypeError, ValueError):
+                        warnings.append(
+                            "auto_wrap_policy.min_num_params must be an integer; ignoring the value."
+                        )
+                    else:
+                        min_params_value = max(1, min_params_value)
+                        plugin_kwargs["auto_wrap_policy"] = size_based_auto_wrap_policy
+                        plugin_kwargs["auto_wrap_policy_kwargs"] = {
+                            "min_num_params": min_params_value
+                        }
+            else:
+                warnings.append(
+                    "Only the 'size_based' auto_wrap_policy is supported in the configuration; ignoring the setting."
+                )
+
+    activation_ckpt_cfg = fsdp_config.get("activation_checkpointing")
+    if isinstance(activation_ckpt_cfg, dict) and activation_ckpt_cfg.get("enabled", False):
+        plugin_kwargs["activation_checkpointing_config"] = activation_ckpt_cfg.get(
+            "config"
+        )
+
+    return FullyShardedDataParallelPlugin(**plugin_kwargs), warnings
 
 
 def prepare_data_list(
@@ -486,8 +677,40 @@ def main(config_path):
 
     desired_device = str(cfg_get_nested(config, 'device', 'cpu')).lower()
     accelerator_kwargs = {}
-    ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
-    accelerator_kwargs['kwargs_handlers'] = [ddp_kwargs]
+    distributed_config = cfg_get_nested(config, 'distributed', {}) or {}
+    fsdp_plugin = None
+    fsdp_warnings = []
+    if isinstance(distributed_config, dict):
+        fsdp_plugin, fsdp_warnings = _build_fsdp_plugin(
+            distributed_config.get('fsdp', {}),
+            desired_device,
+        )
+    else:
+        distributed_config = {}
+
+    if fsdp_plugin is not None:
+        accelerator_kwargs['fsdp_plugin'] = fsdp_plugin
+    else:
+        ddp_config = distributed_config.get('ddp', {}) if isinstance(distributed_config, dict) else {}
+        ddp_options = {}
+        if isinstance(ddp_config, dict):
+            if 'find_unused_parameters' in ddp_config:
+                ddp_options['find_unused_parameters'] = bool(ddp_config['find_unused_parameters'])
+            if 'broadcast_buffers' in ddp_config:
+                ddp_options['broadcast_buffers'] = bool(ddp_config['broadcast_buffers'])
+            if 'gradient_as_bucket_view' in ddp_config:
+                ddp_options['gradient_as_bucket_view'] = bool(ddp_config['gradient_as_bucket_view'])
+            if 'static_graph' in ddp_config:
+                ddp_options['static_graph'] = bool(ddp_config['static_graph'])
+            if 'bucket_cap_mb' in ddp_config and ddp_config['bucket_cap_mb'] is not None:
+                try:
+                    ddp_options['bucket_cap_mb'] = int(ddp_config['bucket_cap_mb'])
+                except (TypeError, ValueError):
+                    pass
+        if 'find_unused_parameters' not in ddp_options:
+            ddp_options['find_unused_parameters'] = True
+        accelerator_kwargs['kwargs_handlers'] = [DistributedDataParallelKwargs(**ddp_options)]
+
     # ``split_batches`` defaults to ``True`` which would further subdivide each
     # dataloader batch across data-parallel workers.  The training scripts
     # already size batches per device, so keep them intact by disabling that
@@ -498,6 +721,12 @@ def main(config_path):
 
     accelerator = Accelerator(**accelerator_kwargs)
     print_fn = accelerator.print
+
+    if fsdp_plugin is not None and accelerator.is_main_process:
+        print_fn("[Distributed] Using Fully Sharded Data Parallel via accelerate.")
+    if fsdp_warnings and accelerator.is_main_process:
+        for warning_msg in fsdp_warnings:
+            print_fn(f"[FSDP] {warning_msg}")
 
     print_fn(f"Loading config data from: {config_path}")
 

--- a/trainer.py
+++ b/trainer.py
@@ -72,6 +72,7 @@ class Trainer(object):
         self.config = config
         self.device = device
         self.accelerator = accelerator
+        self._accelerator_scaler = getattr(self.accelerator, 'scaler', None) if self.accelerator is not None else None
         self.finish_train = False
         self.logger = logger
         self.fp16_run = False
@@ -155,8 +156,15 @@ class Trainer(object):
         grad_scaler_cfg = mp_cfg.get('grad_scaler', {}) if isinstance(mp_cfg, dict) else {}
         if not isinstance(grad_scaler_cfg, dict):
             grad_scaler_cfg = {}
-        scaler_enabled = bool(grad_scaler_cfg.get('enabled', True)) and self.autocast_enabled
-        if scaler_enabled:
+        self._uses_accelerator_scaler = self._accelerator_scaler is not None
+        scaler_enabled = (
+            bool(grad_scaler_cfg.get('enabled', True))
+            and self.autocast_enabled
+            and not self._uses_accelerator_scaler
+        )
+        if self._uses_accelerator_scaler:
+            self.grad_scaler = self._accelerator_scaler
+        elif scaler_enabled:
             init_scale = float(grad_scaler_cfg.get('init_scale', 65536.0))
             growth_factor = float(grad_scaler_cfg.get('growth_factor', 2.0))
             backoff_factor = float(grad_scaler_cfg.get('backoff_factor', 0.5))
@@ -806,7 +814,10 @@ class Trainer(object):
         text_mask = self._maybe_create_text_mask(text_input_length)
 
         autocast_dtype = self.mixed_precision_dtype if self.autocast_enabled else None
-        grad_scaler = self.grad_scaler if self.grad_scaler is not None else None
+        using_accelerator = self.accelerator is not None
+        grad_scaler = (
+            self.grad_scaler if self.grad_scaler is not None and not using_accelerator else None
+        )
 
         if self.autocast_enabled:
             autocast_cm = amp.autocast(
@@ -992,13 +1003,22 @@ class Trainer(object):
 
             grad_scaler.update()
         else:
-            if self.accelerator is not None:
+            if using_accelerator:
                 self.accelerator.backward(loss)
             else:
                 loss.backward()
             torch.nn.utils.clip_grad_value_(self.model.parameters(), 5)
-            self.optimizer.step()
-            optimizer_step_ran = True
+            if using_accelerator:
+                should_step = bool(getattr(self.accelerator, 'sync_gradients', True))
+                if should_step:
+                    # The accelerator-wrapped optimizer handles gradient scaling when needed.
+                    self.optimizer.step()
+                    optimizer_step_ran = True
+                else:
+                    optimizer_step_ran = False
+            else:
+                self.optimizer.step()
+                optimizer_step_ran = True
 
         if optimizer_step_ran:
             self._optimizer_step_count += 1

--- a/trainer.py
+++ b/trainer.py
@@ -532,9 +532,15 @@ class Trainer(object):
             "epochs": self.epochs,
         }
         model_to_save = self.model
+        model_state = None
         if self.accelerator is not None:
             model_to_save = self.accelerator.unwrap_model(self.model)
-        state_dict["model"] = model_to_save.state_dict()
+            get_state_dict = getattr(self.accelerator, "get_state_dict", None)
+            if callable(get_state_dict):
+                model_state = get_state_dict(model_to_save)
+        if model_state is None:
+            model_state = model_to_save.state_dict()
+        state_dict["model"] = model_state
 
         if not os.path.exists(os.path.dirname(checkpoint_path)):
             os.makedirs(os.path.dirname(checkpoint_path))


### PR DESCRIPTION
## Summary
- add configuration-driven support for Accelerate's Fully Sharded Data Parallel plugin and supporting helpers
- expose distributed training options in the default config and document the workflow in the README
- ensure checkpoints leverage accelerator.get_state_dict so FSDP shards consolidate correctly

## Testing
- python -m compileall train.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68da93469a2c833286891837c04c2c01