### PR TITLE
Improve CTC stability on small datasets

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -158,11 +158,16 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
-diagonal_attention_prior_weight: 0.1
+diagonal_attention_prior_weight: 0.3
+diagonal_attention_prior_sigma: 0.35
 
 # stabilizes ASR training for smaller datasets
 entropy_params:
   label_smoothing: 0.1
+
+ctc_loss:
+  blank_logit_bias: 1.5
+  logit_temperature: 1.1
 
 dataset_params:
   # SpecAugment parameters applied only on the training split.
@@ -271,7 +276,7 @@ loss_weights:
   frame_phoneme: 0.0
   speaker: 0.0
   pronunciation_error: 0.0
-  intermediate_ctc: 0.0
+  intermediate_ctc: 0.3
   # Weight applied to the auxiliary loss from the self-conditioned CTC predictor.
   self_conditioned_ctc: 0.0
 
@@ -286,7 +291,7 @@ regularization:
       # Entropy penalties can be enabled independently for each prediction head.
       ctc:
         enabled: true
-        weight: 0.0
+        weight: 0.02
         length_normalize: true
       s2s:
         enabled: true

--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -166,8 +166,21 @@ entropy_params:
   label_smoothing: 0.1
 
 ctc_loss:
-  blank_logit_bias: 1.5
-  logit_temperature: 1.1
+  blank_logit_bias: 1.0
+  logit_temperature: 1.05
+  regularization:
+    blank_rate:
+      enabled: true
+      weight: 0.4
+      target: 0.64
+      tolerance: 0.04
+      warmup_epochs: 3
+    coverage:
+      enabled: true
+      weight: 0.3
+      min_ratio: 0.95
+      tolerance: 0.05
+      warmup_epochs: 3
 
 dataset_params:
   # SpecAugment parameters applied only on the training split.

--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -87,6 +87,7 @@ model_params:
    token_embedding_dim: 512
    n_layers: 5
    location_kernel_size: 31
+   attention_dropout: 0.1
 
 multi_task:
   use_ctc: true
@@ -158,7 +159,10 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
-diagonal_attention_prior_weight: 0.3
+diagonal_attention_prior_weight:
+  initial: 0.3
+  target: 0.4
+  warmup_epochs: 40
 diagonal_attention_prior_sigma: 0.35
 
 # stabilizes ASR training for smaller datasets
@@ -166,17 +170,17 @@ entropy_params:
   label_smoothing: 0.1
 
 ctc_loss:
-  blank_logit_bias: 1.0
-  logit_temperature: 1.05
+  blank_logit_bias: 0.0
+  logit_temperature: 1.0
   regularization:
     blank_rate:
-      enabled: true
+      enabled: false
       weight: 0.4
       target: 0.64
       tolerance: 0.04
       warmup_epochs: 3
     coverage:
-      enabled: true
+      enabled: false
       weight: 0.3
       min_ratio: 0.95
       tolerance: 0.05
@@ -314,11 +318,14 @@ regularization:
 decoding:
   beam_search:
     enabled: true
-    beam_width: 10
+    beam_width: 16
     blank_id: 0
-    length_penalty: 0.0
+    length_penalty: 0.7
     prune_threshold: 1.0e-4
     log_probs_input: false
+    logit_temperature: 1.1
+    blank_penalty: 0.05
+    insertion_bonus: 0.05
   shallow_fusion:
     enabled: false
     lm_path: null  # path to whitespace-separated phoneme n-gram counts
@@ -339,3 +346,9 @@ decoding:
       sos_id: 1
       dropout: 0.0
       checkpoint: null
+
+checkpoint_selection:
+  enabled: true
+  lambda_diag: 0.3
+  lambda_length: 0.2
+  target_length_diff: 0.0

--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -1,7 +1,7 @@
 log_dir: "Checkpoint"
 save_freq: 10
 device: "cuda"
-epochs: 200
+epochs: 250
 batch_size: 64
 pretrained_model: true
 load_only_params: false
@@ -160,10 +160,11 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
 diagonal_attention_prior_weight:
-  initial: 0.3
-  target: 0.4
-  warmup_epochs: 40
-diagonal_attention_prior_sigma: 0.35
+  initial: 0.35
+  target: 0.65
+  warmup_epochs: 60
+  hold_epochs: 20
+diagonal_attention_prior_sigma: 0.32
 
 # stabilizes ASR training for smaller datasets
 entropy_params:
@@ -174,17 +175,26 @@ ctc_loss:
   logit_temperature: 1.0
   regularization:
     blank_rate:
-      enabled: false
-      weight: 0.4
-      target: 0.64
-      tolerance: 0.04
-      warmup_epochs: 3
-    coverage:
-      enabled: false
-      weight: 0.3
-      min_ratio: 0.95
+      enabled: true
+      weight: 0.25
+      target: 0.62
       tolerance: 0.05
-      warmup_epochs: 3
+      warmup_epochs: 5
+      penalize_low_blank: false
+    coverage:
+      enabled: true
+      weight: 0.12
+      min_ratio: 0.92
+      tolerance: 0.03
+      warmup_epochs: 5
+
+alignment_regularization:
+  attention_duration:
+    enabled: true
+    weight: 0.15
+    min_frames: 2.0
+    tolerance: 0.3
+    warmup_epochs: 8
 
 dataset_params:
   # SpecAugment parameters applied only on the training split.

--- a/README.md
+++ b/README.md
@@ -103,18 +103,20 @@ Each augmentation block can be toggled on or off independently through `Configs/
 
 #### Keeping the CTC branch expressive
 
-When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The configuration offers a set of knobs that counteract this behaviour:
+When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The default configuration keeps the training logits unbiased while exposing optional knobs that you can enable when you notice blank over-confidence:
 
 ```yaml
 ctc_loss:
-  blank_logit_bias: 1.0      # subtracts a constant from the blank logit before the softmax
-  logit_temperature: 1.05    # flattens the CTC posterior to discourage over-confidence
+  blank_logit_bias: 0.0      # subtracts a constant from the blank logit before the softmax (kept neutral by default)
+  logit_temperature: 1.0     # flattens the CTC posterior to discourage over-confidence
   regularization:
     blank_rate:
+      enabled: false         # toggle on once alignments have stabilised if blanks dominate
       weight: 0.4            # penalise batches whose blank rate exceeds ~0.64
       target: 0.64
       tolerance: 0.04        # slack before the penalty ramps up
     coverage:
+      enabled: false         # optional coverage regulariser to avoid extreme deletions
       weight: 0.3            # encourage enough non-blank mass to cover the transcript length
       min_ratio: 0.95
       tolerance: 0.05        # allows slight under-coverage before the loss activates
@@ -126,9 +128,23 @@ regularization:
         weight: 0.02         # maximise entropy to keep non-blank symbols active
 ```
 
-Both regularisers honour an optional `warmup_epochs` key (set to `3` in the default config) so you can delay their activation until the CTC alignment has roughly converged.
+Both regularisers honour an optional `warmup_epochs` key (set to `3` in the example above) so you can delay their activation until the CTC alignment has roughly converged.
 
-Additionally, the diagonal attention prior now masks out padded timesteps and exposes a `diagonal_attention_prior_sigma` parameter so that you can tune how tightly the model should follow the diagonal on shorter utterances.
+Decoding-time safeguards provide gentler blank suppression without distorting training. The beam-search configuration supports a temperature, blank penalty, insertion bonus, and lightweight length normalisation:
+
+```yaml
+decoding:
+  beam_search:
+    beam_width: 16
+    length_penalty: 0.7
+    logit_temperature: 1.1  # applied only during decoding
+    blank_penalty: 0.05     # subtract from blank log-probabilities to reduce deletions
+    insertion_bonus: 0.05   # encourages emitting non-blank symbols when hypotheses compete
+```
+
+Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and can be scheduled via `diagonal_attention_prior_weight` to ramp the guidance weight from the warm-up phase towards a stronger late-epoch value.
+
+To avoid choosing checkpoints that only excel at PER while misaligning attention or dropping symbols, training now logs a joint selection score that blends PER, diagonal coherence, and the normalised CTC length gap. The configuration exposes the coefficients under `checkpoint_selection` and the trainer will keep a `best_joint.pth` symlink pointing at the most alignment-friendly checkpoint observed so far.
 
 Increasing the warm-up ratio (`optimizer_params.pct_start`) or reducing the batch size can also help when the number of training utterances is limited.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Each augmentation block can be toggled on or off independently through `Configs/
 
 #### Keeping the CTC branch expressive
 
-When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The default configuration keeps the training logits unbiased while exposing optional knobs that you can enable when you notice blank over-confidence:
+When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The default configuration now enables gentle blank-rate and coverage regularisers so deletions are discouraged without overwhelming the core losses:
 
 ```yaml
 ctc_loss:
@@ -111,15 +111,22 @@ ctc_loss:
   logit_temperature: 1.0     # flattens the CTC posterior to discourage over-confidence
   regularization:
     blank_rate:
-      enabled: false         # toggle on once alignments have stabilised if blanks dominate
-      weight: 0.4            # penalise batches whose blank rate exceeds ~0.64
-      target: 0.64
-      tolerance: 0.04        # slack before the penalty ramps up
+      enabled: true          # applies a mild hinge penalty when the blank posterior dominates
+      weight: 0.25           # penalise batches whose blank rate exceeds ~0.62
+      target: 0.62
+      tolerance: 0.05        # slack before the penalty ramps up
     coverage:
-      enabled: false         # optional coverage regulariser to avoid extreme deletions
-      weight: 0.3            # encourage enough non-blank mass to cover the transcript length
-      min_ratio: 0.95
-      tolerance: 0.05        # allows slight under-coverage before the loss activates
+      enabled: true          # encourages enough non-blank mass to cover the transcript length
+      weight: 0.12
+      min_ratio: 0.92
+      tolerance: 0.03        # allows slight under-coverage before the loss activates
+
+alignment_regularization:
+  attention_duration:
+    enabled: true            # prevents the attention map from collapsing to 1–2 frame spikes
+    weight: 0.15             # average penalty applied when tokens fall below the minimum duration
+    min_frames: 2.0
+    tolerance: 0.3
 
 regularization:
   entropy:
@@ -128,7 +135,7 @@ regularization:
         weight: 0.02         # maximise entropy to keep non-blank symbols active
 ```
 
-Both regularisers honour an optional `warmup_epochs` key (set to `3` in the example above) so you can delay their activation until the CTC alignment has roughly converged.
+All of the auxiliary losses honour a `warmup_epochs` key (`5` for the CTC penalties and `8` for the duration term in the default config) so you can delay their activation until the alignment has roughly converged.
 
 Decoding-time safeguards provide gentler blank suppression without distorting training. The beam-search configuration supports a temperature, blank penalty, insertion bonus, and lightweight length normalisation:
 
@@ -142,7 +149,7 @@ decoding:
     insertion_bonus: 0.05   # encourages emitting non-blank symbols when hypotheses compete
 ```
 
-Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and can be scheduled via `diagonal_attention_prior_weight` to ramp the guidance weight from the warm-up phase towards a stronger late-epoch value.
+Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and is scheduled via `diagonal_attention_prior_weight` so it ramps from a moderate early weight to a stronger late-epoch value. Coupled with the duration regulariser above, this keeps alignments monotonic while ensuring each phoneme retains a multi-frame footprint.
 
 To avoid choosing checkpoints that only excel at PER while misaligning attention or dropping symbols, training now logs a joint selection score that blends PER, diagonal coherence, and the normalised CTC length gap. The configuration exposes the coefficients under `checkpoint_selection` and the trainer will keep a `best_joint.pth` symlink pointing at the most alignment-friendly checkpoint observed so far.
 

--- a/README.md
+++ b/README.md
@@ -103,12 +103,21 @@ Each augmentation block can be toggled on or off independently through `Configs/
 
 #### Keeping the CTC branch expressive
 
-When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The configuration offers two knobs that counteract this behaviour:
+When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The configuration offers a set of knobs that counteract this behaviour:
 
 ```yaml
 ctc_loss:
-  blank_logit_bias: 1.5      # subtracts a constant from the blank logit before the softmax
-  logit_temperature: 1.1     # flattens the CTC posterior to discourage over-confidence
+  blank_logit_bias: 1.0      # subtracts a constant from the blank logit before the softmax
+  logit_temperature: 1.05    # flattens the CTC posterior to discourage over-confidence
+  regularization:
+    blank_rate:
+      weight: 0.4            # penalise batches whose blank rate exceeds ~0.64
+      target: 0.64
+      tolerance: 0.04        # slack before the penalty ramps up
+    coverage:
+      weight: 0.3            # encourage enough non-blank mass to cover the transcript length
+      min_ratio: 0.95
+      tolerance: 0.05        # allows slight under-coverage before the loss activates
 
 regularization:
   entropy:
@@ -116,6 +125,8 @@ regularization:
       ctc:
         weight: 0.02         # maximise entropy to keep non-blank symbols active
 ```
+
+Both regularisers honour an optional `warmup_epochs` key (set to `3` in the default config) so you can delay their activation until the CTC alignment has roughly converged.
 
 Additionally, the diagonal attention prior now masks out padded timesteps and exposes a `diagonal_attention_prior_sigma` parameter so that you can tune how tightly the model should follow the diagonal on shorter utterances.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,24 @@ loss_weights:
 
 Each augmentation block can be toggled on or off independently through `Configs/config.yml`, allowing you to combine time warping, adaptive masking, frame dropping, VTLP, noise/reverberation mixing (including MUSAN and room impulse responses), and phoneme-level dropout as needed.
 
+#### Keeping the CTC branch expressive
+
+When the auxiliary ASR is trained on only a few hours of speech, the CTC head can collapse into predicting mostly blanks, which hurts diagonal alignments and increases the skip/merge gap. The configuration offers two knobs that counteract this behaviour:
+
+```yaml
+ctc_loss:
+  blank_logit_bias: 1.5      # subtracts a constant from the blank logit before the softmax
+  logit_temperature: 1.1     # flattens the CTC posterior to discourage over-confidence
+
+regularization:
+  entropy:
+    targets:
+      ctc:
+        weight: 0.02         # maximise entropy to keep non-blank symbols active
+```
+
+Additionally, the diagonal attention prior now masks out padded timesteps and exposes a `diagonal_attention_prior_sigma` parameter so that you can tune how tightly the model should follow the diagonal on shorter utterances.
+
 Increasing the warm-up ratio (`optimizer_params.pct_start`) or reducing the batch size can also help when the number of training utterances is limited.
 
 ### Languages

--- a/Utils/run_probe_suite.py
+++ b/Utils/run_probe_suite.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python
+"""Run the core AuxiliaryASR notebook diagnostics from the command line.
+
+This helper consolidates the metrics from the ``AuxiliaryASR_*`` analysis
+notebooks so they can be executed in one pass without launching Jupyter.  It
+loads the latest checkpoint from the supplied directory, evaluates the
+validation split, and prints notebook-style summaries for quick reporting.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+from torch import nn
+import yaml
+
+import sys
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from utils import (  # noqa: E402
+    build_dev_dataloader_from_config,
+    load_asr_model_from_config,
+    select_logits_from_output,
+)
+
+
+def _resolve_checkpoint_path(path: Path) -> Path:
+    """Return the checkpoint file that should be evaluated."""
+
+    if path.is_file():
+        return path
+
+    if not path.is_dir():
+        raise FileNotFoundError(f"Checkpoint path '{path}' does not exist")
+
+    preferred = [
+        "best_joint.pth",
+        "best_model.pth",
+        "best_per.pth",
+        "best_loss.pth",
+    ]
+    for name in preferred:
+        candidate = path / name
+        if candidate.exists():
+            return candidate
+
+    epoch_files: List[Tuple[int, Path]] = []
+    for file in path.glob("epoch_*.pth"):
+        parts = file.stem.split("_")
+        try:
+            epoch = int(parts[-1])
+        except (ValueError, IndexError):
+            continue
+        epoch_files.append((epoch, file))
+
+    if not epoch_files:
+        raise FileNotFoundError(
+            f"Could not find any epoch checkpoints inside '{path}'."
+        )
+
+    epoch_files.sort(key=lambda item: item[0])
+    return epoch_files[-1][1]
+
+
+def _load_config(config_path: Optional[Path]) -> Dict:
+    if config_path is None:
+        raise FileNotFoundError("A configuration file must be provided")
+    with config_path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle)
+
+
+def _infer_config_path(checkpoint: Path, explicit: Optional[Path]) -> Path:
+    if explicit is not None:
+        return explicit
+    if checkpoint.is_file():
+        candidate = checkpoint.parent / "config.yml"
+        if candidate.exists():
+            return candidate
+    else:
+        candidate = checkpoint / "config.yml"
+        if candidate.exists():
+            return candidate
+    fallback = ROOT_DIR / "Configs" / "config.yml"
+    if fallback.exists():
+        return fallback
+    raise FileNotFoundError(
+        "Unable to locate a configuration file. Pass --config explicitly."
+    )
+
+
+def _extract_ctc_logits(output) -> torch.Tensor:
+    if isinstance(output, dict):
+        for key in ("logits_ctc", "ctc_logits", "primary_logits", "logits"):
+            tensor = output.get(key)
+            if isinstance(tensor, torch.Tensor):
+                return tensor
+    if isinstance(output, (tuple, list)) and output:
+        candidate = output[0]
+        if isinstance(candidate, torch.Tensor):
+            return candidate
+    tensor = select_logits_from_output(output)
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError("Unable to extract logits tensor from model output")
+    return tensor
+
+
+@torch.no_grad()
+def compute_ctc_entropy(model: torch.nn.Module, dev_loader, device, blank_id: int) -> Dict[str, float]:
+    model.eval()
+    entropies: List[float] = []
+    max_probs: List[float] = []
+    blank_rates: List[float] = []
+    downsample_factor = 2 ** getattr(model, "n_down", 1)
+
+    for batch in dev_loader:
+        texts, text_lens, mels, mel_lens = batch[:4]
+        mels = mels.to(device)
+        mel_lens = mel_lens.to(torch.long)
+
+        outputs = model(mels)
+        logits = _extract_ctc_logits(outputs)
+
+        logp = logits.log_softmax(-1).cpu()
+        probs = logp.exp()
+        entropy = -(probs * logp).sum(-1)
+        maxp, ids = probs.max(-1)
+        blank_mask = ids.eq(blank_id)
+
+        logit_lens = torch.clamp(
+            mel_lens // downsample_factor,
+            min=1,
+            max=logits.size(1),
+        ).cpu()
+
+        for h, m, bmask, L in zip(entropy, maxp, blank_mask, logit_lens):
+            length = int(L)
+            entropies.append(h[:length].mean().item())
+            max_probs.append(m[:length].mean().item())
+            blank_rates.append(bmask[:length].float().mean().item())
+
+    return {
+        "mean_entropy": float(torch.tensor(entropies).mean()),
+        "mean_maxprob": float(torch.tensor(max_probs).mean()),
+        "mean_blank_rate": float(torch.tensor(blank_rates).mean()),
+    }
+
+
+@torch.no_grad()
+def compute_ctc_loss(model: torch.nn.Module, dev_loader, device, blank_id: int) -> float:
+    model_was_training = model.training
+    model.eval()
+
+    criterion = nn.CTCLoss(blank=blank_id, zero_infinity=True)
+    losses: List[float] = []
+    downsample = 2 ** getattr(model, "n_down", 1)
+
+    for batch in dev_loader:
+        texts, text_lens, mels, mel_lens = batch[:4]
+
+        mels = mels.to(device)
+        targets = texts.to(device=device, dtype=torch.long)
+        text_lens = text_lens.to(torch.long)
+        mel_lens = mel_lens.to(torch.long)
+
+        outputs = model(mels)
+        logits = _extract_ctc_logits(outputs)
+
+        if logits.dim() != 3:
+            raise ValueError(f"Unexpected logits shape: {tuple(logits.shape)}")
+
+        max_logit_steps = logits.size(1)
+        logit_lens = torch.clamp(mel_lens // downsample, min=1)
+        logit_lens = torch.minimum(
+            logit_lens,
+            torch.full_like(logit_lens, max_logit_steps),
+        )
+
+        logp = logits.log_softmax(-1).transpose(0, 1)
+        loss = criterion(logp, targets, logit_lens, text_lens)
+        losses.append(float(loss.item()))
+
+    if model_was_training:
+        model.train()
+
+    return float(sum(losses) / max(1, len(losses)))
+
+
+@torch.no_grad()
+def diagonal_attention_score(
+    model: torch.nn.Module,
+    dev_loader,
+    device: torch.device,
+    band: float = 0.1,
+    max_batches: Optional[int] = None,
+) -> Tuple[float, List[float]]:
+    model.eval()
+    diag_scores: List[float] = []
+    downsample = 2 ** getattr(model, "n_down", 1)
+
+    for batch_idx, batch in enumerate(dev_loader):
+        if max_batches is not None and batch_idx >= max_batches:
+            break
+
+        texts, text_lens, mels, mel_lens = batch[:4]
+        mels = mels.to(device)
+        texts = texts.to(device)
+        text_lens = text_lens.to(torch.long)
+        mel_lens = mel_lens.to(device=device, dtype=torch.long)
+
+        reduced_mel_lens = torch.clamp(mel_lens // downsample, min=1)
+        mel_mask = model.length_to_mask(reduced_mel_lens)
+
+        outputs = model(
+            mels,
+            src_key_padding_mask=mel_mask,
+            text_input=texts,
+        )
+
+        attn = None
+        if isinstance(outputs, dict):
+            for key in ("s2s_attn", "attn", "attention", "alignments"):
+                tensor = outputs.get(key)
+                if tensor is not None:
+                    attn = tensor
+                    break
+            if attn is None:
+                available = ", ".join(outputs.keys())
+                raise KeyError(
+                    "Model output dictionary does not contain attention "
+                    f"matrices. Available keys: {available}"
+                )
+        elif isinstance(outputs, (tuple, list)):
+            if len(outputs) < 3:
+                raise ValueError(
+                    "Model forward output does not include attention tensors."
+                )
+            attn = outputs[2]
+        else:
+            raise TypeError(
+                "Unsupported model output type for attention extraction."
+            )
+
+        attn = attn.detach()
+        time_axis = attn.size(-1)
+        output_axis = attn.size(1)
+
+        text_lens_list = text_lens.tolist()
+        mel_lens_list = reduced_mel_lens.tolist()
+
+        for b in range(attn.size(0)):
+            To = min(int(text_lens_list[b]), output_axis)
+            Te = min(int(mel_lens_list[b]), time_axis)
+            if To <= 1 or Te <= 1:
+                continue
+
+            a = attn[b, :To, :Te]
+            total_mass = a.sum()
+            if torch.isclose(total_mass, torch.tensor(0.0, device=a.device)):
+                continue
+
+            t = torch.arange(To, device=a.device, dtype=torch.float32).unsqueeze(1)
+            e = torch.arange(Te, device=a.device, dtype=torch.float32).unsqueeze(0)
+            t = t / (To - 1) if To > 1 else torch.zeros_like(t)
+            e = e / (Te - 1) if Te > 1 else torch.zeros_like(e)
+            diag = t - e
+            mask = (diag.abs() <= band).to(a.dtype)
+
+            score = (a * mask).sum() / total_mass.clamp_min(1e-8)
+            diag_scores.append(float(score))
+
+    mean_score = float(np.mean(diag_scores)) if diag_scores else float("nan")
+    return mean_score, diag_scores
+
+
+@torch.no_grad()
+def best_path_durations(logits: torch.Tensor, lens: torch.Tensor, blank_id: int):
+    ids_all: List[List[int]] = []
+    durs_all: List[List[int]] = []
+    path = logits.argmax(-1)
+    for b in range(path.size(0)):
+        prev = None
+        ids_b: List[int] = []
+        durs_b: List[int] = []
+        T = int(lens[b])
+        for t in range(T):
+            cur = int(path[b, t])
+            if cur == blank_id:
+                prev = cur
+                continue
+            if prev != cur:
+                ids_b.append(cur)
+                durs_b.append(1)
+            else:
+                durs_b[-1] += 1
+            prev = cur
+        ids_all.append(ids_b)
+        durs_all.append(durs_b)
+    return ids_all, durs_all
+
+
+@torch.no_grad()
+def duration_stats(
+    model: torch.nn.Module,
+    dev_loader,
+    device: torch.device,
+    blank_id: int,
+) -> Dict[str, float]:
+    model.eval()
+    all_durs: List[int] = []
+    ratios: List[float] = []
+    downsample_factor = 2 ** getattr(model, "n_down", 1)
+
+    for batch in dev_loader:
+        texts, text_lens, mels, mel_lens = batch[:4]
+        mels = mels.to(device)
+        mel_lens = mel_lens.to(torch.long)
+
+        outputs = model(mels)
+        logits = _extract_ctc_logits(outputs).detach().cpu()
+        logit_lens = torch.clamp(
+            mel_lens // downsample_factor,
+            min=1,
+            max=logits.size(1),
+        ).cpu()
+        _, durs = best_path_durations(logits, logit_lens, blank_id)
+
+        mel_lens_cpu = mel_lens.cpu()
+        for mel_len, dur in zip(mel_lens_cpu, durs):
+            if not dur:
+                continue
+            ratios.append(float(mel_len.item()) / len(dur))
+            all_durs.extend(dur)
+
+    if not all_durs:
+        raise RuntimeError(
+            "No non-blank token durations collected; check the model outputs."
+        )
+
+    all_durs_np = np.array(all_durs, dtype=np.float32)
+    ratios_np = np.array(ratios, dtype=np.float32)
+    return {
+        "mean_dur_frames": float(all_durs_np.mean()),
+        "p50": float(np.percentile(all_durs_np, 50)),
+        "p90": float(np.percentile(all_durs_np, 90)),
+        "frames_per_token_mean": float(ratios_np.mean()),
+    }
+
+
+@torch.no_grad()
+def skip_merge_flags(
+    model: torch.nn.Module,
+    dev_loader,
+    device: torch.device,
+    blank_id: int,
+) -> Dict[str, float]:
+    model.eval()
+    diffs: List[float] = []
+    downsample_factor = 2 ** getattr(model, "n_down", 1)
+
+    for batch in dev_loader:
+        texts, text_lens, mels, mel_lens = batch[:4]
+        mels = mels.to(device)
+        text_lens = text_lens.to(torch.long)
+        mel_lens = mel_lens.to(torch.long)
+
+        outputs = model(mels)
+        logits = _extract_ctc_logits(outputs).detach().cpu()
+        logit_lens = torch.clamp(
+            mel_lens // downsample_factor,
+            min=1,
+            max=logits.size(1),
+        ).cpu()
+
+        ids, _ = best_path_durations(logits, logit_lens, blank_id)
+        tgt_lens = text_lens.cpu().tolist()
+
+        for collapsed, tlen in zip(ids, tgt_lens):
+            diffs.append(len(collapsed) - int(tlen))
+
+    if not diffs:
+        raise RuntimeError(
+            "No samples processed when computing skip-merge statistics."
+        )
+
+    diffs_np = np.array(diffs, dtype=np.float32)
+    return {
+        "mean_len_diff": float(diffs_np.mean()),
+        "p10": float(np.percentile(diffs_np, 10)),
+        "p90": float(np.percentile(diffs_np, 90)),
+    }
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run AuxiliaryASR diagnostic probes without notebooks.",
+    )
+    parser.add_argument(
+        "checkpoint",
+        type=str,
+        help="Path to a checkpoint file or directory containing epoch_*.pth files.",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Optional path to a training configuration file (defaults to the one next to the checkpoint).",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default=None,
+        help="Computation device override (e.g. 'cuda:0' or 'cpu').",
+    )
+    parser.add_argument(
+        "--band",
+        type=float,
+        default=0.1,
+        help="Diagonal attention tolerance band (default: 0.1).",
+    )
+    parser.add_argument(
+        "--max-align-batches",
+        type=int,
+        default=None,
+        help="Limit the number of batches when computing the diagonal score.",
+    )
+    args = parser.parse_args(argv)
+
+    checkpoint_arg = Path(args.checkpoint)
+    checkpoint_file = _resolve_checkpoint_path(checkpoint_arg)
+    config_path = _infer_config_path(
+        checkpoint_arg, Path(args.config) if args.config else None
+    )
+
+    config = _load_config(config_path)
+
+    if args.device:
+        device = torch.device(args.device)
+    else:
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    model, token_map = load_asr_model_from_config(config, str(checkpoint_file), device)
+    dev_loader, _ = build_dev_dataloader_from_config(config, device)
+
+    if " " not in token_map:
+        raise KeyError("The vocabulary does not contain the blank symbol ' '.")
+    blank_id = int(token_map[" "])
+
+    print("=== AuxiliaryASR_CTC_Entropy ===")
+    entropy_stats = compute_ctc_entropy(model, dev_loader, device, blank_id)
+    for key, value in entropy_stats.items():
+        print(f"{key}: {value:.6f}")
+    print()
+
+    print("=== AuxiliaryASR_CTC_Loss ===")
+    dev_loss = compute_ctc_loss(model, dev_loader, device, blank_id)
+    print(f"Dev mean CTC loss: {dev_loss:.4f}")
+    print()
+
+    print("=== AuxiliaryASR_Diagonal_Attention ===")
+    mean_diag, diag_scores = diagonal_attention_score(
+        model,
+        dev_loader,
+        device,
+        band=args.band,
+        max_batches=args.max_align_batches,
+    )
+    print(f"Diagonal attention score: {mean_diag:.4f}")
+    print(f"Evaluated {len(diag_scores)} alignments")
+    if diag_scores:
+        scores_np = np.array(diag_scores, dtype=np.float32)
+        print("Score statistics:")
+        print(f"  min:  {scores_np.min():.4f}")
+        print(f"  25%:  {np.percentile(scores_np, 25):.4f}")
+        print(f"  median: {np.median(scores_np):.4f}")
+        print(f"  75%:  {np.percentile(scores_np, 75):.4f}")
+        print(f"  max:  {scores_np.max():.4f}")
+    print()
+
+    print("=== AuxiliaryASR_Duration_Stats ===")
+    dur_stats = duration_stats(model, dev_loader, device, blank_id)
+    for key, value in dur_stats.items():
+        print(f"{key}: {value:.6f}")
+    print()
+
+    print("=== AuxiliaryASR_SkipMergeFlags ===")
+    skip_stats = skip_merge_flags(model, dev_loader, device, blank_id)
+    for key, value in skip_stats.items():
+        print(f"{key}: {value:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/decoding.py
+++ b/decoding.py
@@ -225,6 +225,9 @@ class CTCBeamSearchDecoder:
         cold_fusion: Optional[ColdFusionCombiner] = None,
         length_penalty: float = 0.0,
         prune_threshold: float = 1e-6,
+        logit_temperature: float = 1.0,
+        blank_penalty: float = 0.0,
+        insertion_bonus: float = 0.0,
     ) -> None:
         self.beam_width = max(1, int(beam_width))
         self.blank_id = int(blank_id)
@@ -235,6 +238,9 @@ class CTCBeamSearchDecoder:
         self.cold_fusion = cold_fusion
         self.length_penalty = float(length_penalty)
         self.prune_threshold = float(prune_threshold)
+        self.logit_temperature = max(1.0e-6, float(logit_temperature))
+        self.blank_penalty = float(blank_penalty)
+        self.insertion_bonus = float(insertion_bonus)
 
     def _init_hypothesis(self) -> Hypothesis:
         shallow_state = self.shallow_fusion_lm.start() if self.shallow_fusion_lm else None
@@ -264,6 +270,10 @@ class CTCBeamSearchDecoder:
         else:
             log_probs = logits
 
+        if self.logit_temperature != 1.0:
+            log_probs = log_probs / self.logit_temperature
+            log_probs = log_probs - torch.logsumexp(log_probs, dim=-1, keepdim=True)
+
         beams: Dict[Tuple[int, ...], Hypothesis] = {
             tuple(): self._init_hypothesis()
         }
@@ -281,7 +291,7 @@ class CTCBeamSearchDecoder:
                 total_log_prob = hyp.score
 
                 # Extend with blank
-                blank_log_prob = frame[self.blank_id].item()
+                blank_log_prob = frame[self.blank_id].item() - self.blank_penalty
                 new_blank_prob = total_log_prob + blank_log_prob
                 updated = candidates.setdefault(hyp.prefix, Hypothesis(prefix=hyp.prefix))
                 updated.log_prob_blank = _log_sum_exp(updated.log_prob_blank, new_blank_prob)
@@ -294,7 +304,7 @@ class CTCBeamSearchDecoder:
                     if symbol == self.blank_id:
                         continue
 
-                    symbol_log_prob = frame[symbol].item()
+                    symbol_log_prob = frame[symbol].item() + self.insertion_bonus
                     prev_symbol = hyp.prefix[-1] if hyp.prefix else None
 
                     shallow_state = hyp.shallow_state
@@ -429,6 +439,9 @@ def build_decoder_from_config(config: dict) -> Optional[CTCBeamSearchDecoder]:
         cold_fusion=cold_combiner,
         length_penalty=beam_cfg.get("length_penalty", 0.0),
         prune_threshold=beam_cfg.get("prune_threshold", 1e-6),
+        logit_temperature=beam_cfg.get("logit_temperature", 1.0),
+        blank_penalty=beam_cfg.get("blank_penalty", 0.0),
+        insertion_bonus=beam_cfg.get("insertion_bonus", 0.0),
     )
     return decoder
 

--- a/layers.py
+++ b/layers.py
@@ -151,7 +151,8 @@ class LocationLayer(nn.Module):
 
 class Attention(nn.Module):
     def __init__(self, attention_rnn_dim, embedding_dim, attention_dim,
-                 attention_location_n_filters, attention_location_kernel_size):
+                 attention_location_n_filters, attention_location_kernel_size,
+                 attention_dropout=0.0):
         super(Attention, self).__init__()
         self.query_layer = LinearNorm(attention_rnn_dim, attention_dim,
                                       bias=False, w_init_gain='tanh')
@@ -162,6 +163,8 @@ class Attention(nn.Module):
                                             attention_location_kernel_size,
                                             attention_dim)
         self.score_mask_value = -float("inf")
+        self.attention_dropout_p = max(0.0, float(attention_dropout))
+        self._attention_dropout = nn.Dropout(p=self.attention_dropout_p) if self.attention_dropout_p > 0.0 else None
 
     def get_alignment_energies(self, query, processed_memory,
                                attention_weights_cat):
@@ -202,6 +205,12 @@ class Attention(nn.Module):
             alignment.data.masked_fill_(mask, self.score_mask_value)
 
         attention_weights = F.softmax(alignment, dim=1)
+
+        if self._attention_dropout is not None and self.attention_dropout_p > 0.0:
+            attention_weights = self._attention_dropout(attention_weights)
+            denom = attention_weights.sum(dim=1, keepdim=True).clamp_min(1.0e-8)
+            attention_weights = attention_weights / denom
+
         attention_context = torch.bmm(attention_weights.unsqueeze(1), memory)
         attention_context = attention_context.squeeze(1)
 

--- a/models.py
+++ b/models.py
@@ -147,6 +147,7 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
+                 attention_dropout=0.0,
                  multi_task_config=None,
                  stabilization_config=None,
                  memory_optimization_config=None,
@@ -270,7 +271,8 @@ class ASRCNN(nn.Module):
             embedding_dim=token_embedding_dim,
             hidden_dim=hidden_dim//2,
             n_token=n_token,
-            location_kernel_size=location_kernel_size)
+            location_kernel_size=location_kernel_size,
+            attention_dropout=attention_dropout)
 
         frame_cfg = self.multi_task_config.get('frame_phoneme', {}) or {}
         self.enable_frame_classifier = bool(frame_cfg.get('enabled', False))
@@ -685,7 +687,8 @@ class ASRS2S(nn.Module):
                  hidden_dim=512,
                  n_location_filters=32,
                  location_kernel_size=63,
-                 n_token=40):
+                 n_token=40,
+                 attention_dropout=0.0):
         super(ASRS2S, self).__init__()
         self.embedding = nn.Embedding(n_token, embedding_dim)
         val_range = math.sqrt(6 / hidden_dim)
@@ -698,7 +701,8 @@ class ASRS2S(nn.Module):
             hidden_dim,
             hidden_dim,
             n_location_filters,
-            location_kernel_size
+            location_kernel_size,
+            attention_dropout=attention_dropout
         )
         self.decoder_rnn = nn.LSTMCell(self.decoder_rnn_dim + embedding_dim, self.decoder_rnn_dim)
         self.project_to_hidden = nn.Sequential(

--- a/train.py
+++ b/train.py
@@ -1090,6 +1090,14 @@ def main(config_path):
     current_train_batch_size = int(initial_batch_size)
     current_samples_per_rank = int(train_samples_per_rank)
 
+    checkpoint_selection_cfg = cfg_get_nested(config, 'checkpoint_selection', {}) or {}
+    joint_selection_enabled = bool(checkpoint_selection_cfg.get('enabled', False))
+    joint_lambda_diag = float(checkpoint_selection_cfg.get('lambda_diag', 0.0))
+    joint_lambda_length = float(checkpoint_selection_cfg.get('lambda_length', 0.0))
+    joint_target_len_diff = float(checkpoint_selection_cfg.get('target_length_diff', 0.0))
+    best_joint_score = None
+    best_checkpoint_path = None
+
     def _ensure_curriculum_for_epoch(epoch):
         nonlocal sorted_train_dataloader
         nonlocal shuffled_train_dataloader
@@ -1186,6 +1194,30 @@ def main(config_path):
 
         results = train_results.copy()
         results.update(eval_results)
+
+        joint_score = None
+        length_penalty = None
+        is_best = False
+        if joint_selection_enabled:
+            per_metric = results.get('eval/wer')
+            diag_metric = results.get('eval/diag_coherence')
+            len_diff_norm = results.get('eval/ctc_len_diff_norm')
+            if per_metric is not None and diag_metric is not None and len_diff_norm is not None:
+                length_penalty = max(0.0, joint_target_len_diff - len_diff_norm)
+                joint_score = per_metric + joint_lambda_diag * (1.0 - diag_metric) + joint_lambda_length * length_penalty
+                results['eval/joint_score'] = joint_score
+                results['eval/length_penalty'] = length_penalty
+                tolerance = 1.0e-6
+                if best_joint_score is None or joint_score < best_joint_score - tolerance:
+                    is_best = True
+
+        if joint_selection_enabled:
+            display_best = best_joint_score
+            if is_best and joint_score is not None:
+                display_best = joint_score
+            if display_best is not None:
+                results['eval/best_joint_score'] = display_best
+
         if accelerator.is_main_process:
             logger.info('--- epoch %d ---' % epoch)
             for key, value in results.items():
@@ -1196,12 +1228,33 @@ def main(config_path):
                     for v in value:
                         writer.add_figure('eval_attn', plot_image(v), epoch)
 
-        if (epoch % save_freq) == 0 or (early_stopping is not None and early_stopping(learning_rate)):
-            if accelerator.is_main_process:
-                trainer.save_checkpoint(osp.join(log_dir, 'epoch_%05d.pth' % epoch))
-            accelerator.wait_for_everyone()
+        should_trigger_early_stop = False
+        if early_stopping is not None:
+            should_trigger_early_stop = early_stopping(learning_rate)
 
-        if early_stopping is not None and early_stopping(learning_rate):
+        save_checkpoint = (epoch % save_freq) == 0 or should_trigger_early_stop or is_best
+        checkpoint_path = None
+        if save_checkpoint and accelerator.is_main_process:
+            checkpoint_path = osp.join(log_dir, 'epoch_%05d.pth' % epoch)
+            trainer.save_checkpoint(checkpoint_path)
+        accelerator.wait_for_everyone()
+
+        if joint_selection_enabled and is_best and joint_score is not None:
+            best_joint_score = joint_score
+            if accelerator.is_main_process and checkpoint_path is not None:
+                best_checkpoint_path = checkpoint_path
+                best_symlink = osp.join(log_dir, 'best_joint.pth')
+                try:
+                    if os.path.islink(best_symlink) or os.path.exists(best_symlink):
+                        os.remove(best_symlink)
+                    os.symlink(os.path.basename(checkpoint_path), best_symlink)
+                except OSError:
+                    shutil.copyfile(checkpoint_path, best_symlink)
+
+        if joint_selection_enabled and best_joint_score is not None:
+            results['eval/best_joint_score'] = best_joint_score
+
+        if should_trigger_early_stop:
             if accelerator.is_main_process:
                 logger.info(f"Early stopping triggered at epoch {epoch}, learning_rate: {learning_rate:.5f}")
             break

--- a/train.py
+++ b/train.py
@@ -985,6 +985,14 @@ def main(config_path):
                 'ctc': {'blank': blank_index, 'reduction': 'none', 'zero_infinity': True},
         }, entropy_params=entropy_params, multi_task_config=multi_task_config)
 
+    ctc_loss_config = cfg_get_nested(config, 'ctc_loss', {}) or {}
+    if not isinstance(ctc_loss_config, dict):
+        ctc_loss_config = {}
+    ctc_blank_bias = float(ctc_loss_config.get('blank_logit_bias', 0.0))
+    ctc_logit_temperature = float(ctc_loss_config.get('logit_temperature', 1.0))
+    if ctc_logit_temperature <= 0:
+        ctc_logit_temperature = 1.0
+
     if enable_early_stopping:
         patience = max([3, int(math.floor(int(cfg_get_nested(config, 'save_freq', 10)) / 2))])
         early_stopping = EarlyStoppingWithNoLearningRate(patience=patience)
@@ -1055,11 +1063,15 @@ def main(config_path):
                     switch_sortagrad_dataset_epoch=cfg_get_nested(config, 'sortagrad_switch_to_shuffled_dataset_epoch', 10),
                     use_diagonal_attention_prior=(cfg_get_nested(config, 'use_diagonal_attention_prior', True) and use_s2s),
                     diagonal_attention_prior_weight=cfg_get_nested(config, 'diagonal_attention_prior_weight', 0.1),
+                    diagonal_attention_prior_sigma=cfg_get_nested(config, 'diagonal_attention_prior_sigma', 0.5),
                     ctc_weight=ctc_weight,
                     s2s_weight=s2s_weight,
                     frame_weight=frame_weight,
                     speaker_weight=speaker_weight,
                     pron_error_weight=pron_weight,
+                    ctc_blank_id=blank_index,
+                    ctc_logit_bias=ctc_blank_bias,
+                    ctc_logit_temperature=ctc_logit_temperature,
                     enable_frame_classifier=frame_cfg.get('enabled', False),
                     enable_speaker=speaker_cfg.get('enabled', False),
                     enable_pronunciation_error=pron_cfg.get('enabled', False),

--- a/train.py
+++ b/train.py
@@ -1177,7 +1177,7 @@ def main(config_path):
         start_epoch = 1
 
     _ensure_curriculum_for_epoch(start_epoch)
-    if trainer._resumed_from_checkpoint:
+    if getattr(trainer, "_resumed_from_checkpoint", False):
         trainer.handle_sortagrad_after_resume()
         completed_steps = _curriculum_completed_steps(trainer.epochs)
         trainer.sync_scheduler_to_progress(completed_steps=completed_steps)

--- a/train.py
+++ b/train.py
@@ -992,6 +992,9 @@ def main(config_path):
     ctc_logit_temperature = float(ctc_loss_config.get('logit_temperature', 1.0))
     if ctc_logit_temperature <= 0:
         ctc_logit_temperature = 1.0
+    ctc_regularization_config = ctc_loss_config.get('regularization', {}) or {}
+    if not isinstance(ctc_regularization_config, dict):
+        ctc_regularization_config = {}
 
     if enable_early_stopping:
         patience = max([3, int(math.floor(int(cfg_get_nested(config, 'save_freq', 10)) / 2))])
@@ -1072,6 +1075,7 @@ def main(config_path):
                     ctc_blank_id=blank_index,
                     ctc_logit_bias=ctc_blank_bias,
                     ctc_logit_temperature=ctc_logit_temperature,
+                    ctc_regularization_config=ctc_regularization_config,
                     enable_frame_classifier=frame_cfg.get('enabled', False),
                     enable_speaker=speaker_cfg.get('enabled', False),
                     enable_pronunciation_error=pron_cfg.get('enabled', False),

--- a/trainer.py
+++ b/trainer.py
@@ -127,6 +127,18 @@ class Trainer(object):
         self.ctc_coverage_regularization_enabled = bool(coverage_reg_cfg.get('enabled', False))
         self.ctc_coverage_regularization_config = coverage_reg_cfg
 
+        alignment_reg_cfg = {}
+        if isinstance(self.config, dict):
+            alignment_reg_cfg = self.config.get('alignment_regularization', {}) or {}
+            if not isinstance(alignment_reg_cfg, dict):
+                alignment_reg_cfg = {}
+
+        attn_duration_cfg = alignment_reg_cfg.get('attention_duration', {}) or {}
+        if not isinstance(attn_duration_cfg, dict):
+            attn_duration_cfg = {}
+        self.attention_duration_regularization_enabled = bool(attn_duration_cfg.get('enabled', False))
+        self.attention_duration_regularization_config = attn_duration_cfg
+
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
         self.mixspeech_prob = float(self.mixspeech_config.get('prob', 0.5))
@@ -337,6 +349,14 @@ class Trainer(object):
             return True
         return self.epochs >= max(warmup, 0)
 
+    def _alignment_regularization_warmup_passed(self, cfg):
+        if cfg is None:
+            return False
+        warmup = int(cfg.get('warmup_epochs', 0))
+        if warmup <= 0:
+            return True
+        return self.epochs >= max(warmup, 0)
+
     def _compute_ctc_alignment_regularization(self, logits, input_lengths, target_lengths):
         if logits is None:
             return {}, {}
@@ -474,6 +494,67 @@ class Trainer(object):
         stats = {
             'diagnostics/ctc_coverage_ratio': float(coverage_ratio.mean().detach().item()),
         }
+        return loss_value, stats
+
+    def _compute_attention_duration_regularization(self, attn, text_lengths, mel_lengths):
+        if not self.attention_duration_regularization_enabled:
+            return None
+
+        cfg = self.attention_duration_regularization_config or {}
+        if not self._alignment_regularization_warmup_passed(cfg):
+            return None
+
+        weight = float(cfg.get('weight', 0.0))
+        if weight == 0.0:
+            return None
+
+        min_frames = float(cfg.get('min_frames', 0.0))
+        tolerance = float(cfg.get('tolerance', 0.0))
+        max_frames = float(cfg.get('max_frames', 0.0))
+
+        device = attn.device
+        text_lengths = text_lengths.to(device=device, dtype=torch.long)
+        mel_lengths = mel_lengths.to(device=device, dtype=torch.long)
+
+        B, T_text, T_mel = attn.size()
+        text_positions = torch.arange(T_text, device=device).view(1, T_text)
+        mel_positions = torch.arange(T_mel, device=device).view(1, T_mel)
+
+        text_mask = (text_positions < text_lengths.view(B, 1)).to(attn.dtype)
+        mel_mask = (mel_positions < mel_lengths.view(B, 1)).to(attn.dtype)
+
+        masked_attn = attn * mel_mask.view(B, 1, T_mel)
+        durations = masked_attn.sum(dim=2)
+
+        denom = text_mask.sum().clamp_min(1.0)
+
+        lower_bound = max(0.0, min_frames - tolerance)
+        penalty = torch.clamp(lower_bound - durations, min=0.0)
+
+        if max_frames > 0.0:
+            upper_bound = max_frames + max(0.0, tolerance)
+            penalty = penalty + torch.clamp(durations - upper_bound, min=0.0)
+
+        penalty = penalty * text_mask
+        average_penalty = penalty.sum() / denom
+
+        loss_value = weight * average_penalty
+
+        stats = {}
+        durations_masked = (durations * text_mask).detach()
+        valid_mask = text_mask.bool()
+        valid_durations = durations_masked[valid_mask]
+        if valid_durations.numel() > 0:
+            stats['diagnostics/attn_duration_mean'] = float(valid_durations.mean().item())
+            stats['diagnostics/attn_duration_min'] = float(valid_durations.min().item())
+            stats['diagnostics/attn_duration_max'] = float(valid_durations.max().item())
+            for quantile, name in ((0.1, 'p10'), (0.5, 'p50'), (0.9, 'p90')):
+                stats[f'diagnostics/attn_duration_{name}'] = float(torch.quantile(valid_durations, quantile).item())
+
+            short_mask = (penalty.detach() * text_mask) > 0
+            short_ratio = short_mask.float().sum() / denom
+            stats['diagnostics/attn_duration_short_ratio'] = float(short_ratio.item())
+
         return loss_value, stats
 
     def _get_target_model(self):
@@ -1265,6 +1346,16 @@ class Trainer(object):
             else:
                 pron_loss = torch.zeros(1, device=self.device)
 
+            if s2s_attn is not None:
+                duration_reg = self._compute_attention_duration_regularization(
+                    s2s_attn, text_input_length, mel_input_length
+                )
+                if duration_reg is not None:
+                    duration_loss, duration_stats = duration_reg
+                    total_loss = total_loss + duration_loss
+                    losses['attn_duration_reg'] = duration_loss.item()
+                    losses.update(duration_stats)
+
             if self.use_diagonal_attention_prior and s2s_attn is not None:
                 diag_weight = self._get_active_diagonal_attention_weight()
                 if diag_weight > 0.0:
@@ -1534,6 +1625,16 @@ class Trainer(object):
                     pron_pred = torch.argmax(pron_logits, dim=2)
                     pron_acc = self._sequence_accuracy(pron_pred, pron_targets)
                     eval_losses['eval/pronunciation_error_acc'].append(self._reduce_scalar(pron_acc))
+
+            if s2s_attn is not None:
+                duration_eval = self._compute_attention_duration_regularization(
+                    s2s_attn, text_input_length, mel_input_length
+                )
+                if duration_eval is not None:
+                    duration_loss, duration_stats = duration_eval
+                    eval_losses.setdefault('eval/attn_duration_reg', []).append(self._reduce_scalar(duration_loss.item()))
+                    for stat_key, stat_value in duration_stats.items():
+                        eval_losses.setdefault(stat_key, []).append(stat_value)
 
             eval_losses["eval/loss"].append(self._reduce_scalar(total_eval_loss.item()))
 

--- a/trainer.py
+++ b/trainer.py
@@ -82,7 +82,7 @@ class Trainer(object):
         self.fp16_run = False
         self.switch_sortagrad_dataset_epoch = switch_sortagrad_dataset_epoch
         self.use_diagonal_attention_prior = use_diagonal_attention_prior
-        self.diagonal_attention_prior_weight = diagonal_attention_prior_weight
+        self._configure_diagonal_attention_weight(diagonal_attention_prior_weight)
         sigma = float(diagonal_attention_prior_sigma)
         self.diagonal_attention_prior_sigma = sigma if sigma > 0 else 0.5
         self.maxm_mem_usage = 0
@@ -158,6 +158,63 @@ class Trainer(object):
             precision_cfg = self.config.get('precision', {}) or {}
             if not isinstance(precision_cfg, dict):
                 precision_cfg = {}
+
+    def _configure_diagonal_attention_weight(self, weight_config):
+        schedule = None
+        base_weight = float(weight_config) if weight_config is not None else 0.0
+        if isinstance(weight_config, dict):
+            initial = float(weight_config.get('initial', weight_config.get('base', weight_config.get('start', 0.0))))
+            target = float(weight_config.get('target', weight_config.get('final', initial)))
+            warmup = int(weight_config.get('warmup_epochs', weight_config.get('ramp_epochs', 0)))
+            hold = int(weight_config.get('hold_epochs', 0))
+            schedule = {
+                'initial': initial,
+                'target': target,
+                'warmup': max(0, warmup),
+                'hold': max(0, hold),
+            }
+            base_weight = initial
+        self.diagonal_attention_prior_weight = float(base_weight)
+        self.diagonal_attention_weight_schedule = schedule
+        self._active_diagonal_attention_weight = float(base_weight)
+
+    def _current_diagonal_attention_weight(self, epoch_index: int) -> float:
+        schedule = self.diagonal_attention_weight_schedule
+        if not schedule:
+            return float(self.diagonal_attention_prior_weight)
+
+        epoch = max(1, int(epoch_index))
+        initial = float(schedule['initial'])
+        target = float(schedule['target'])
+        warmup = int(schedule['warmup'])
+        hold = int(schedule['hold'])
+
+        if warmup <= 0:
+            weight = target
+        else:
+            progress = min(1.0, max(0.0, (epoch - 1) / float(max(1, warmup))))
+            weight = initial + (target - initial) * progress
+
+        if epoch > warmup + hold:
+            weight = target
+
+        return float(weight)
+
+    def _set_active_diagonal_attention_weight(self, training: bool) -> None:
+        if not self.use_diagonal_attention_prior:
+            self._active_diagonal_attention_weight = 0.0
+            return
+
+        if training:
+            epoch_index = self.epochs + 1
+        else:
+            epoch_index = max(1, self.epochs)
+
+        weight = self._current_diagonal_attention_weight(epoch_index)
+        self._active_diagonal_attention_weight = weight
+
+    def _get_active_diagonal_attention_weight(self) -> float:
+        return float(getattr(self, '_active_diagonal_attention_weight', self.diagonal_attention_prior_weight))
         mp_cfg = precision_cfg.get('mixed_precision', {}) if isinstance(precision_cfg, dict) else {}
         if not isinstance(mp_cfg, dict):
             mp_cfg = {}
@@ -525,6 +582,19 @@ class Trainer(object):
                 'reduction': str(cfg.get('reduction', 'mean')).lower(),
             }
         return parsed
+
+    @staticmethod
+    def _collapse_tokens(tokens, ignore_indexes=None):
+        if ignore_indexes is None:
+            ignore_indexes = []
+        filtered = [int(tok) for tok in tokens if int(tok) not in ignore_indexes]
+        if not filtered:
+            return []
+        collapsed = [filtered[0]]
+        for tok in filtered[1:]:
+            if tok != collapsed[-1]:
+                collapsed.append(tok)
+        return collapsed
 
     def _entropy_target_config(self, key):
         if not self.entropy_regularization_enabled:
@@ -1166,14 +1236,17 @@ class Trainer(object):
                 pron_loss = torch.zeros(1, device=self.device)
 
             if self.use_diagonal_attention_prior and s2s_attn is not None:
-                loss_diagonal = diagonal_attention_prior(
-                    s2s_attn,
-                    text_input_length,
-                    mel_input_length,
-                    sigma=self.diagonal_attention_prior_sigma,
-                )
-                total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
-                losses['diag_attn'] = loss_diagonal.item()
+                diag_weight = self._get_active_diagonal_attention_weight()
+                if diag_weight > 0.0:
+                    loss_diagonal = diagonal_attention_prior(
+                        s2s_attn,
+                        text_input_length,
+                        mel_input_length,
+                        sigma=self.diagonal_attention_prior_sigma,
+                    )
+                    total_loss = total_loss + diag_weight * loss_diagonal
+                    losses['diag_attn'] = loss_diagonal.item()
+                    losses['diag_attn_weight'] = float(diag_weight)
 
             loss = total_loss
 
@@ -1240,6 +1313,7 @@ class Trainer(object):
 
         train_losses = defaultdict(list)
         self.model.train()
+        self._set_active_diagonal_attention_weight(training=True)
         if self.accelerator is not None and not self.accelerator.is_local_main_process:
             data_iterator = self.train_dataloader
         else:
@@ -1274,6 +1348,7 @@ class Trainer(object):
     @torch.no_grad()
     def _eval_epoch(self):
         self.model.eval()
+        self._set_active_diagonal_attention_weight(training=False)
         eval_losses = defaultdict(list)
         eval_images = defaultdict(list)
         if self.accelerator is not None and not self.accelerator.is_local_main_process:
@@ -1434,13 +1509,38 @@ class Trainer(object):
 
             if ppgs is not None:
                 _, amax_ppgs = torch.max(ppgs, dim=2)
-                wers = [calc_wer(target[:text_length],
-                                 pred[:mel_length],
-                                 ignore_indexes=list(range(5))) \
-                        for target, pred, text_length, mel_length in zip(
-                                text_input.cpu(), amax_ppgs.cpu(), text_input_length.cpu(), mel_input_length.cpu())]
+                wers = []
+                len_diffs = []
+                len_diff_norms = []
+                ignore_indexes = list(range(5))
+                for target, pred, text_length, mel_length in zip(
+                    text_input.cpu(),
+                    amax_ppgs.cpu(),
+                    text_input_length.cpu(),
+                    mel_input_length.cpu(),
+                ):
+                    target_seq = target[:text_length]
+                    pred_seq = pred[:mel_length]
+                    wers.append(
+                        calc_wer(
+                            target_seq,
+                            pred_seq,
+                            ignore_indexes=ignore_indexes,
+                        )
+                    )
+                    collapsed_target = self._collapse_tokens(target_seq.tolist(), ignore_indexes)
+                    collapsed_pred = self._collapse_tokens(pred_seq.tolist(), ignore_indexes)
+                    diff = float(len(collapsed_pred) - len(collapsed_target))
+                    len_diffs.append(diff)
+                    ref_len = max(1.0, float(len(collapsed_target)))
+                    len_diff_norms.append(diff / ref_len)
+
                 wers = self._gather_metric_list(wers)
+                len_diffs = self._gather_metric_list(len_diffs)
+                len_diff_norms = self._gather_metric_list(len_diff_norms)
                 eval_losses["eval/wer"].extend(wers)
+                eval_losses["eval/ctc_len_diff"].extend(len_diffs)
+                eval_losses["eval/ctc_len_diff_norm"].extend(len_diff_norms)
 
             if s2s_pred is not None:
                 _, amax_s2s = torch.max(s2s_pred, dim=2)
@@ -1449,12 +1549,25 @@ class Trainer(object):
                 acc = self._gather_metric_list(acc)
                 eval_losses["eval/acc"].extend(acc)
 
-            if s2s_attn is not None and eval_steps_per_epoch <= 2:
-                if self.accelerator is None or self.accelerator.is_main_process:
-                    eval_images["eval/image"].append(
-                        self.get_image([s2s_attn[0].cpu().numpy()]))
+            if s2s_attn is not None:
+                diag_scores = diagonal_attention_coherence(
+                    s2s_attn,
+                    text_input_length,
+                    mel_input_length,
+                    sigma=self.diagonal_attention_prior_sigma,
+                )
+                if isinstance(diag_scores, torch.Tensor):
+                    diag_scores = diag_scores.detach().cpu().tolist()
+                diag_scores = self._gather_metric_list(diag_scores)
+                eval_losses["eval/diag_coherence"].extend(diag_scores)
+
+                if eval_steps_per_epoch <= 2:
+                    if self.accelerator is None or self.accelerator.is_main_process:
+                        eval_images["eval/image"].append(
+                            self.get_image([s2s_attn[0].cpu().numpy()]))
 
         eval_losses = {key: np.mean(value) for key, value in eval_losses.items()}
+        eval_losses.setdefault('eval/diag_weight', self._get_active_diagonal_attention_weight())
         eval_losses.update(eval_images)
         for key in list(eval_losses.keys()):
             if key.startswith('eval/image'):

--- a/trainer.py
+++ b/trainer.py
@@ -42,6 +42,7 @@ class Trainer(object):
                  switch_sortagrad_dataset_epoch = 10,
                  use_diagonal_attention_prior = True,
                  diagonal_attention_prior_weight = 0.1,
+                 diagonal_attention_prior_sigma = 0.5,
                  ctc_weight=1.0,
                  s2s_weight=1.0,
                  frame_weight=0.0,
@@ -50,6 +51,9 @@ class Trainer(object):
                  enable_frame_classifier=False,
                  enable_speaker=False,
                  enable_pronunciation_error=False,
+                 ctc_blank_id=0,
+                 ctc_logit_bias=0.0,
+                 ctc_logit_temperature=1.0,
                  mixspeech_config=None,
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
@@ -78,6 +82,8 @@ class Trainer(object):
         self.switch_sortagrad_dataset_epoch = switch_sortagrad_dataset_epoch
         self.use_diagonal_attention_prior = use_diagonal_attention_prior
         self.diagonal_attention_prior_weight = diagonal_attention_prior_weight
+        sigma = float(diagonal_attention_prior_sigma)
+        self.diagonal_attention_prior_sigma = sigma if sigma > 0 else 0.5
         self.maxm_mem_usage = 0
         self.steps_per_epoch = steps_per_epoch if steps_per_epoch is None else int(steps_per_epoch)
         self.ctc_weight = ctc_weight
@@ -88,6 +94,11 @@ class Trainer(object):
         self.enable_frame_classifier = enable_frame_classifier
         self.enable_speaker = enable_speaker
         self.enable_pronunciation_error = enable_pronunciation_error
+
+        self.ctc_blank_id = int(ctc_blank_id)
+        self.ctc_blank_logit_bias = float(ctc_logit_bias)
+        temperature = float(ctc_logit_temperature)
+        self.ctc_logit_temperature = temperature if temperature > 0 else 1.0
 
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
@@ -196,6 +207,23 @@ class Trainer(object):
                 self.train_dataloader = self.shuffled_train_dataloader
             if self.shuffled_val_dataloader is not None:
                 self.val_dataloader = self.shuffled_val_dataloader
+
+    def _adjust_ctc_logits(self, logits):
+        """Apply optional blank bias and temperature scaling to CTC logits."""
+        if logits is None:
+            return logits
+
+        bias = self.ctc_blank_logit_bias
+        temperature = self.ctc_logit_temperature
+
+        adjusted = logits
+        if bias != 0.0 and 0 <= self.ctc_blank_id < logits.size(-1):
+            adjusted = logits.clone()
+            adjusted[..., self.ctc_blank_id] = adjusted[..., self.ctc_blank_id] - bias
+        if temperature != 1.0:
+            adjusted = adjusted / temperature
+
+        return adjusted
 
     def _get_target_model(self):
         """Return the underlying model, unwrapping accelerator/DDP wrappers."""
@@ -368,6 +396,9 @@ class Trainer(object):
         cfg = self._entropy_target_config(key)
         if cfg is None:
             return None
+
+        if key == 'ctc':
+            logits = self._adjust_ctc_logits(logits)
 
         logits = logits.float()
         probs = torch.softmax(logits, dim=-1)
@@ -734,6 +765,7 @@ class Trainer(object):
         return mixed, metadata
 
     def _compute_ctc_loss(self, logits, targets, input_lengths, target_lengths, mix_metadata=None):
+        logits = self._adjust_ctc_logits(logits)
         ctc = self.criterion['ctc']
         log_probs = logits.log_softmax(dim=2).transpose(0, 1)
         primary_loss = ctc(log_probs, targets, input_lengths, target_lengths)
@@ -961,7 +993,12 @@ class Trainer(object):
                 pron_loss = torch.zeros(1, device=self.device)
 
             if self.use_diagonal_attention_prior and s2s_attn is not None:
-                loss_diagonal = diagonal_attention_prior(s2s_attn, text_input_length, mel_input_length)
+                loss_diagonal = diagonal_attention_prior(
+                    s2s_attn,
+                    text_input_length,
+                    mel_input_length,
+                    sigma=self.diagonal_attention_prior_sigma,
+                )
                 total_loss = total_loss + self.diagonal_attention_prior_weight * loss_diagonal
                 losses['diag_attn'] = loss_diagonal.item()
 

--- a/trainer.py
+++ b/trainer.py
@@ -224,6 +224,35 @@ class Trainer(object):
         else:
             self.grad_scaler = None
 
+        # Scheduler/step bookkeeping: align with whatever the optimiser already
+        # recorded so resumed runs don't double-step, and ensure the attribute
+        # always exists before training starts.
+        self._scheduler_aligned = False
+        self._optimizer_step_count = self._get_optimizer_step_count()
+
+        # Work out whether SortaGrad should remain active after initialisation
+        # now that dataloaders are wired up. We seeded the attribute early so
+        # that partially constructed trainers expose it, but the final decision
+        # depends on the availability of both sorted and shuffled loaders.
+        sortagrad_possible = (
+            self.sorted_train_dataloader is not None
+            and self.shuffled_train_dataloader is not None
+            and self.switch_sortagrad_dataset_epoch is not None
+            and self.switch_sortagrad_dataset_epoch > 0
+        )
+
+        if sortagrad_possible:
+            self._sortagrad_active = True
+            self.train_dataloader = self.sorted_train_dataloader
+            if self.sorted_val_dataloader is not None:
+                self.val_dataloader = self.sorted_val_dataloader
+        else:
+            self._sortagrad_active = False
+            if self.shuffled_train_dataloader is not None:
+                self.train_dataloader = self.shuffled_train_dataloader
+            if self.shuffled_val_dataloader is not None:
+                self.val_dataloader = self.shuffled_val_dataloader
+
     def _configure_diagonal_attention_weight(self, weight_config):
         schedule = None
         if isinstance(weight_config, dict):
@@ -282,21 +311,6 @@ class Trainer(object):
 
     def _get_active_diagonal_attention_weight(self) -> float:
         return float(getattr(self, '_active_diagonal_attention_weight', self.diagonal_attention_prior_weight))
-
-        self._scheduler_aligned = False
-        self._optimizer_step_count = self._get_optimizer_step_count()
-        self._sortagrad_active = bool(
-            self.sorted_train_dataloader
-            and self.shuffled_train_dataloader
-            and self.switch_sortagrad_dataset_epoch is not None
-            and self.switch_sortagrad_dataset_epoch > 0
-        )
-
-        if not self._sortagrad_active:
-            if self.shuffled_train_dataloader is not None:
-                self.train_dataloader = self.shuffled_train_dataloader
-            if self.shuffled_val_dataloader is not None:
-                self.val_dataloader = self.shuffled_val_dataloader
 
     def _adjust_ctc_logits(self, logits):
         """Apply optional blank bias and temperature scaling to CTC logits."""

--- a/trainer.py
+++ b/trainer.py
@@ -169,6 +169,61 @@ class Trainer(object):
             if not isinstance(precision_cfg, dict):
                 precision_cfg = {}
 
+        mp_cfg = precision_cfg.get('mixed_precision', {}) if isinstance(precision_cfg, dict) else {}
+        if not isinstance(mp_cfg, dict):
+            mp_cfg = {}
+
+        dtype_map = {
+            'float16': torch.float16,
+            'fp16': torch.float16,
+            'half': torch.float16,
+            'bfloat16': torch.bfloat16,
+            'bf16': torch.bfloat16,
+        }
+        dtype_key = str(mp_cfg.get('dtype', 'float16')).lower()
+        self.mixed_precision_dtype = dtype_map.get(dtype_key, torch.float16)
+
+        autocast_requested = bool(mp_cfg.get('enabled', False))
+        device_type = self.device.type if isinstance(self.device, torch.device) else str(self.device)
+        if not isinstance(device_type, str):
+            device_type = str(device_type)
+        device_type = device_type.lower()
+        is_cuda_device = device_type.startswith('cuda')
+        cuda_available = torch.cuda.is_available()
+
+        self.autocast_device_type = 'cuda' if is_cuda_device else device_type or 'cuda'
+        self.autocast_enabled = autocast_requested and is_cuda_device and cuda_available
+
+        grad_scaler_cfg = mp_cfg.get('grad_scaler', {}) if isinstance(mp_cfg, dict) else {}
+        if not isinstance(grad_scaler_cfg, dict):
+            grad_scaler_cfg = {}
+
+        scaler_enabled = bool(grad_scaler_cfg.get('enabled', True)) and self.autocast_enabled
+        if scaler_enabled:
+            init_scale = float(grad_scaler_cfg.get('init_scale', 65536.0))
+            growth_factor = float(grad_scaler_cfg.get('growth_factor', 2.0))
+            backoff_factor = float(grad_scaler_cfg.get('backoff_factor', 0.5))
+            growth_interval = int(grad_scaler_cfg.get('growth_interval', 2000))
+            scaler_kwargs = dict(
+                enabled=True,
+                init_scale=init_scale,
+                growth_factor=growth_factor,
+                backoff_factor=backoff_factor,
+                growth_interval=growth_interval,
+            )
+
+            try:
+                scaler_params = inspect.signature(amp.GradScaler.__init__).parameters
+            except (ValueError, TypeError):
+                scaler_params = {}
+
+            if 'device_type' in scaler_params:
+                scaler_kwargs['device_type'] = self.autocast_device_type
+
+            self.grad_scaler = amp.GradScaler(**scaler_kwargs)
+        else:
+            self.grad_scaler = None
+
     def _configure_diagonal_attention_weight(self, weight_config):
         schedule = None
         if isinstance(weight_config, dict):
@@ -227,56 +282,6 @@ class Trainer(object):
 
     def _get_active_diagonal_attention_weight(self) -> float:
         return float(getattr(self, '_active_diagonal_attention_weight', self.diagonal_attention_prior_weight))
-        mp_cfg = precision_cfg.get('mixed_precision', {}) if isinstance(precision_cfg, dict) else {}
-        if not isinstance(mp_cfg, dict):
-            mp_cfg = {}
-        dtype_map = {
-            'float16': torch.float16,
-            'fp16': torch.float16,
-            'half': torch.float16,
-            'bfloat16': torch.bfloat16,
-            'bf16': torch.bfloat16,
-        }
-        dtype_key = str(mp_cfg.get('dtype', 'float16')).lower()
-        self.mixed_precision_dtype = dtype_map.get(dtype_key, torch.float16)
-        autocast_enabled = bool(mp_cfg.get('enabled', False))
-        device_type = self.device.type if isinstance(self.device, torch.device) else str(self.device)
-        self.autocast_enabled = (
-            autocast_enabled
-            and torch.cuda.is_available()
-            and isinstance(device_type, str)
-            and device_type.startswith('cuda')
-        )
-        self.autocast_device_type = 'cuda'
-
-        grad_scaler_cfg = mp_cfg.get('grad_scaler', {}) if isinstance(mp_cfg, dict) else {}
-        if not isinstance(grad_scaler_cfg, dict):
-            grad_scaler_cfg = {}
-        scaler_enabled = bool(grad_scaler_cfg.get('enabled', True)) and self.autocast_enabled
-        if scaler_enabled:
-            init_scale = float(grad_scaler_cfg.get('init_scale', 65536.0))
-            growth_factor = float(grad_scaler_cfg.get('growth_factor', 2.0))
-            backoff_factor = float(grad_scaler_cfg.get('backoff_factor', 0.5))
-            growth_interval = int(grad_scaler_cfg.get('growth_interval', 2000))
-            scaler_kwargs = dict(
-                enabled=True,
-                init_scale=init_scale,
-                growth_factor=growth_factor,
-                backoff_factor=backoff_factor,
-                growth_interval=growth_interval,
-            )
-
-            try:
-                scaler_params = inspect.signature(amp.GradScaler.__init__).parameters
-            except (ValueError, TypeError):
-                scaler_params = {}
-
-            if 'device_type' in scaler_params:
-                scaler_kwargs['device_type'] = self.autocast_device_type
-
-            self.grad_scaler = amp.GradScaler(**scaler_kwargs)
-        else:
-            self.grad_scaler = None
 
         self._scheduler_aligned = False
         self._optimizer_step_count = self._get_optimizer_step_count()

--- a/trainer.py
+++ b/trainer.py
@@ -70,6 +70,10 @@ class Trainer(object):
         # assignment. This also provides backwards compatibility with older
         # call-sites that expect the attribute to exist unconditionally.
         self._resumed_from_checkpoint = bool(initial_epochs)
+        # Default SortaGrad state so callers can always rely on the attribute
+        # existing even if initialisation aborts before the full dataloader
+        # wiring runs.
+        self._sortagrad_active = False
         self.model = model
         self.criterion = criterion
         self.optimizer = optimizer

--- a/trainer.py
+++ b/trainer.py
@@ -161,7 +161,6 @@ class Trainer(object):
 
     def _configure_diagonal_attention_weight(self, weight_config):
         schedule = None
-        base_weight = float(weight_config) if weight_config is not None else 0.0
         if isinstance(weight_config, dict):
             initial = float(weight_config.get('initial', weight_config.get('base', weight_config.get('start', 0.0))))
             target = float(weight_config.get('target', weight_config.get('final', initial)))
@@ -174,6 +173,9 @@ class Trainer(object):
                 'hold': max(0, hold),
             }
             base_weight = initial
+        else:
+            base_weight = float(weight_config) if weight_config is not None else 0.0
+
         self.diagonal_attention_prior_weight = float(base_weight)
         self.diagonal_attention_weight_schedule = schedule
         self._active_diagonal_attention_weight = float(base_weight)

--- a/trainer.py
+++ b/trainer.py
@@ -54,6 +54,7 @@ class Trainer(object):
                  ctc_blank_id=0,
                  ctc_logit_bias=0.0,
                  ctc_logit_temperature=1.0,
+                 ctc_regularization_config=None,
                  mixspeech_config=None,
                  intermediate_ctc_config=None,
                  self_conditioned_ctc_config=None,
@@ -99,6 +100,22 @@ class Trainer(object):
         self.ctc_blank_logit_bias = float(ctc_logit_bias)
         temperature = float(ctc_logit_temperature)
         self.ctc_logit_temperature = temperature if temperature > 0 else 1.0
+
+        ctc_reg_cfg = ctc_regularization_config or {}
+        if not isinstance(ctc_reg_cfg, dict):
+            ctc_reg_cfg = {}
+
+        blank_reg_cfg = ctc_reg_cfg.get('blank_rate', {}) or {}
+        if not isinstance(blank_reg_cfg, dict):
+            blank_reg_cfg = {}
+        self.ctc_blank_rate_regularization_enabled = bool(blank_reg_cfg.get('enabled', False))
+        self.ctc_blank_rate_regularization_config = blank_reg_cfg
+
+        coverage_reg_cfg = ctc_reg_cfg.get('coverage', {}) or {}
+        if not isinstance(coverage_reg_cfg, dict):
+            coverage_reg_cfg = {}
+        self.ctc_coverage_regularization_enabled = bool(coverage_reg_cfg.get('enabled', False))
+        self.ctc_coverage_regularization_config = coverage_reg_cfg
 
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
@@ -224,6 +241,153 @@ class Trainer(object):
             adjusted = adjusted / temperature
 
         return adjusted
+
+    def _ctc_regularization_warmup_passed(self, cfg):
+        if cfg is None:
+            return False
+        warmup = int(cfg.get('warmup_epochs', 0))
+        if warmup <= 0:
+            return True
+        return self.epochs >= max(warmup, 0)
+
+    def _compute_ctc_alignment_regularization(self, logits, input_lengths, target_lengths):
+        if logits is None:
+            return {}, {}
+
+        enabled = self.ctc_blank_rate_regularization_enabled or self.ctc_coverage_regularization_enabled
+        if not enabled:
+            return {}, {}
+
+        adjusted = self._adjust_ctc_logits(logits)
+        probs = torch.softmax(adjusted.float(), dim=-1)
+
+        reg_losses = {}
+        reg_stats = {}
+
+        if self.ctc_blank_rate_regularization_enabled:
+            blank_cfg = self.ctc_blank_rate_regularization_config
+            if self._ctc_regularization_warmup_passed(blank_cfg):
+                blank_result = self._compute_ctc_blank_rate_regularization(probs, input_lengths, blank_cfg)
+                if blank_result is not None:
+                    loss_value, stats = blank_result
+                    reg_losses['ctc/blank_rate_reg'] = loss_value
+                    reg_stats.update(stats)
+
+        if self.ctc_coverage_regularization_enabled:
+            coverage_cfg = self.ctc_coverage_regularization_config
+            if self._ctc_regularization_warmup_passed(coverage_cfg):
+                coverage_result = self._compute_ctc_coverage_regularization(
+                    probs, input_lengths, target_lengths, coverage_cfg
+                )
+                if coverage_result is not None:
+                    loss_value, stats = coverage_result
+                    reg_losses['ctc/coverage_reg'] = loss_value
+                    reg_stats.update(stats)
+
+        return reg_losses, reg_stats
+
+    def _compute_ctc_blank_rate_regularization(self, probs, input_lengths, cfg):
+        blank_id = self.ctc_blank_id
+        if blank_id < 0 or blank_id >= probs.size(-1):
+            return None
+
+        weight = float(cfg.get('weight', 0.0))
+        if weight == 0.0:
+            return None
+
+        blank_probs = probs[..., blank_id]
+        if blank_probs.dim() != 2:
+            return None
+
+        mask = None
+        if input_lengths is not None:
+            if not torch.is_tensor(input_lengths):
+                input_lengths = torch.as_tensor(input_lengths, device=blank_probs.device)
+            input_lengths = input_lengths.to(device=blank_probs.device, dtype=torch.long)
+            max_len = blank_probs.size(1)
+            mask = torch.arange(max_len, device=blank_probs.device).unsqueeze(0)
+            mask = mask < input_lengths.unsqueeze(1)
+            mask = mask.to(blank_probs.dtype)
+
+        if mask is not None:
+            effective = mask.sum(dim=1).clamp_min(1.0)
+            blank_rate = (blank_probs * mask).sum(dim=1) / effective
+        else:
+            blank_rate = blank_probs.mean(dim=1)
+
+        target = float(cfg.get('target', cfg.get('target_blank_rate', 0.65)))
+        tolerance = float(cfg.get('tolerance', 0.0))
+        upper = min(max(target + tolerance, 0.0), 1.0)
+        lower = max(min(target - tolerance, 1.0), 0.0)
+
+        over_penalty = torch.clamp(blank_rate - upper, min=0.0)
+        if bool(cfg.get('penalize_low_blank', False)):
+            under_penalty = torch.clamp(lower - blank_rate, min=0.0)
+        else:
+            under_penalty = torch.zeros_like(over_penalty)
+
+        penalty = over_penalty + under_penalty
+        loss_value = penalty.mean() * weight
+
+        stats = {
+            'diagnostics/ctc_blank_rate': float(blank_rate.mean().detach().item()),
+        }
+        return loss_value, stats
+
+    def _compute_ctc_coverage_regularization(self, probs, input_lengths, target_lengths, cfg):
+        blank_id = self.ctc_blank_id
+        if blank_id < 0 or blank_id >= probs.size(-1):
+            return None
+
+        weight = float(cfg.get('weight', 0.0))
+        if weight == 0.0:
+            return None
+
+        if target_lengths is None:
+            return None
+        if not torch.is_tensor(target_lengths):
+            target_lengths = torch.as_tensor(target_lengths, device=probs.device)
+        target_lengths = target_lengths.to(device=probs.device, dtype=torch.float32)
+
+        non_blank = 1.0 - probs[..., blank_id]
+        if non_blank.dim() != 2:
+            return None
+
+        mask = None
+        if input_lengths is not None:
+            if not torch.is_tensor(input_lengths):
+                input_lengths = torch.as_tensor(input_lengths, device=non_blank.device)
+            input_lengths = input_lengths.to(device=non_blank.device, dtype=torch.long)
+            max_len = non_blank.size(1)
+            mask = torch.arange(max_len, device=non_blank.device).unsqueeze(0)
+            mask = mask < input_lengths.unsqueeze(1)
+            mask = mask.to(non_blank.dtype)
+
+        if mask is not None:
+            coverage_mass = (non_blank * mask).sum(dim=1)
+        else:
+            coverage_mass = non_blank.sum(dim=1)
+
+        denom = target_lengths.clamp_min(1.0)
+        coverage_ratio = coverage_mass / denom
+
+        min_ratio = float(cfg.get('min_ratio', 1.0))
+        tolerance = float(cfg.get('tolerance', 0.0))
+        lower_bound = max(min_ratio - tolerance, 0.0)
+        penalty = torch.clamp(lower_bound - coverage_ratio, min=0.0)
+
+        max_ratio = cfg.get('max_ratio', None)
+        if max_ratio is not None:
+            max_ratio = float(max_ratio)
+            upper_bound = max_ratio + max(0.0, tolerance)
+            penalty = penalty + torch.clamp(coverage_ratio - upper_bound, min=0.0)
+
+        loss_value = penalty.mean() * weight
+
+        stats = {
+            'diagnostics/ctc_coverage_ratio': float(coverage_ratio.mean().detach().item()),
+        }
+        return loss_value, stats
 
     def _get_target_model(self):
         """Return the underlying model, unwrapping accelerator/DDP wrappers."""
@@ -861,6 +1025,15 @@ class Trainer(object):
                 losses['ctc'] = loss_ctc.item()
             else:
                 loss_ctc = torch.zeros(1, device=self.device)
+
+            reg_losses, reg_stats = self._compute_ctc_alignment_regularization(
+                ppgs, mel_input_length, text_input_length
+            )
+            for key, value in reg_losses.items():
+                total_loss = total_loss + value
+                losses[key] = value.item() if torch.is_tensor(value) else float(value)
+            for key, value in reg_stats.items():
+                losses[key] = float(value)
 
             s2s_pred = model_outputs.get('s2s_logits')
             s2s_attn = model_outputs.get('s2s_attn')

--- a/trainer.py
+++ b/trainer.py
@@ -64,6 +64,12 @@ class Trainer(object):
 
         self.steps = initial_steps
         self.epochs = initial_epochs
+        # Track whether the trainer is resuming from an existing checkpoint as
+        # early as possible so downstream logic can safely query the flag even
+        # if initialisation is interrupted before reaching the later
+        # assignment. This also provides backwards compatibility with older
+        # call-sites that expect the attribute to exist unconditionally.
+        self._resumed_from_checkpoint = bool(initial_epochs)
         self.model = model
         self.criterion = criterion
         self.optimizer = optimizer
@@ -268,7 +274,6 @@ class Trainer(object):
         else:
             self.grad_scaler = None
 
-        self._resumed_from_checkpoint = bool(initial_epochs)
         self._scheduler_aligned = False
         self._optimizer_step_count = self._get_optimizer_step_count()
         self._sortagrad_active = bool(

--- a/utils.py
+++ b/utils.py
@@ -452,6 +452,48 @@ def diagonal_attention_prior(attn, text_lengths, mel_lengths, sigma=0.5, eps=1.0
     return loss
 
 
+def diagonal_attention_coherence(attn, text_lengths, mel_lengths, sigma=0.5, eps=1.0e-6):
+    """Return the per-sample diagonal alignment score in ``[0, 1]``."""
+
+    if attn is None:
+        raise ValueError("'attn' must be a tensor")
+
+    if sigma <= 0:
+        raise ValueError("'sigma' must be positive")
+
+    if not torch.is_tensor(text_lengths):
+        text_lengths = torch.as_tensor(text_lengths, device=attn.device)
+    if not torch.is_tensor(mel_lengths):
+        mel_lengths = torch.as_tensor(mel_lengths, device=attn.device)
+
+    B, T_text, T_mel = attn.size()
+    device = attn.device
+
+    text_lengths = text_lengths.to(device=device, dtype=torch.float32)
+    mel_lengths = mel_lengths.to(device=device, dtype=torch.float32)
+
+    text_positions = torch.arange(T_text, device=device, dtype=torch.float32).view(1, T_text, 1)
+    mel_positions = torch.arange(T_mel, device=device, dtype=torch.float32).view(1, 1, T_mel)
+
+    text_scale = torch.clamp(text_lengths.view(B, 1, 1) - 1.0, min=1.0)
+    mel_scale = torch.clamp(mel_lengths.view(B, 1, 1) - 1.0, min=1.0)
+
+    text_norm = torch.clamp(text_positions / text_scale, 0.0, 1.0).expand(B, -1, -1)
+    mel_norm = torch.clamp(mel_positions / mel_scale, 0.0, 1.0).expand(B, -1, -1)
+
+    expected = torch.exp(-((text_norm - mel_norm) ** 2) / (2 * sigma ** 2))
+    expected = expected / expected.amax(dim=(1, 2), keepdim=True).clamp_min(eps)
+
+    text_mask = (text_positions.long() < text_lengths.view(B, 1, 1).long()).expand(B, -1, T_mel)
+    mel_mask = (mel_positions.long() < mel_lengths.view(B, 1, 1).long()).expand(B, T_text, -1)
+    mask = (text_mask & mel_mask).to(attn.dtype)
+
+    expected_mass = (expected * mask).sum(dim=(1, 2)).clamp_min(eps)
+    alignment_mass = (attn * expected * mask).sum(dim=(1, 2))
+
+    return alignment_mass / expected_mass
+
+
 class BatchSizeScheduler:
     """Utility to manage curriculum batch-size schedules.
 

--- a/utils.py
+++ b/utils.py
@@ -400,19 +400,55 @@ def plot_image(image):
 
     return fig
 
-def diagonal_attention_prior(attn, text_lengths, mel_lengths, sigma=0.5):
-    """Calculate diagonal attention loss."""
-    B, T_text, T_mel = attn.size()  # usually [B, T_text, T_mel]
+def diagonal_attention_prior(attn, text_lengths, mel_lengths, sigma=0.5, eps=1.0e-6):
+    """Calculate diagonal attention loss with length-aware masking.
+
+    Args:
+        attn: Attention weights of shape ``[B, T_text, T_mel]``.
+        text_lengths: Tensor containing the valid number of text tokens per batch item.
+        mel_lengths: Tensor containing the valid number of mel frames per batch item.
+        sigma: Controls the width of the diagonal Gaussian prior.
+        eps: Numerical stability constant.
+    """
+
+    if attn is None:
+        raise ValueError("'attn' must be a tensor")
+
+    if sigma <= 0:
+        raise ValueError("'sigma' must be positive")
+
+    B, T_text, T_mel = attn.size()
     device = attn.device
 
-    # Normalize indices
-    text_pos = torch.arange(T_text, device=device).unsqueeze(1).float() / T_text
-    mel_pos = torch.arange(T_mel, device=device).unsqueeze(0).float() / T_mel
-    expected = torch.exp(-((text_pos - mel_pos) ** 2) / (2 * sigma ** 2))  # [T_text, T_mel]
-    expected = expected / expected.max()  # Normalize
+    text_lengths = text_lengths.to(device=device, dtype=torch.float32)
+    mel_lengths = mel_lengths.to(device=device, dtype=torch.float32)
 
-    expected = expected.unsqueeze(0).expand(B, -1, -1)  # [B, T_text, T_mel]
-    loss = torch.mean(attn * (1.0 - expected))  # Encourage attention mass to lie on the diagonal
+    text_positions = torch.arange(T_text, device=device, dtype=torch.float32).view(1, T_text, 1)
+    mel_positions = torch.arange(T_mel, device=device, dtype=torch.float32).view(1, 1, T_mel)
+
+    text_scale = torch.clamp(text_lengths.view(B, 1, 1) - 1.0, min=1.0)
+    mel_scale = torch.clamp(mel_lengths.view(B, 1, 1) - 1.0, min=1.0)
+
+    text_norm = torch.clamp(text_positions / text_scale, 0.0, 1.0)
+    mel_norm = torch.clamp(mel_positions / mel_scale, 0.0, 1.0)
+
+    # Broadcast to [B, T_text, T_mel]
+    text_norm = text_norm.expand(B, -1, -1)
+    mel_norm = mel_norm.expand(B, -1, -1)
+
+    expected = torch.exp(-((text_norm - mel_norm) ** 2) / (2 * sigma ** 2))
+    expected = expected / expected.amax(dim=(1, 2), keepdim=True).clamp_min(eps)
+
+    text_mask = (text_positions.long() < text_lengths.view(B, 1, 1).long()).expand(B, -1, T_mel)
+    mel_mask = (mel_positions.long() < mel_lengths.view(B, 1, 1).long()).expand(B, T_text, -1)
+    valid_mask = text_mask & mel_mask
+
+    mask = valid_mask.to(attn.dtype)
+    denom = mask.sum()
+    if denom.item() <= 0:
+        return torch.tensor(0.0, device=device, dtype=attn.dtype)
+
+    loss = (attn * (1.0 - expected) * mask).sum() / denom
     return loss
 
 


### PR DESCRIPTION
## Summary
- add configurable blank-logit bias and temperature scaling for the CTC head to mitigate blank collapse on tiny corpora
- strengthen diagonal attention supervision with a length-aware prior and expose its sigma in the config
- increase intermediate CTC and entropy regularisation defaults and document the new tuning knobs for small datasets

## Testing
- python -m compileall trainer.py utils.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68e16e7d832c833287a2af09acb1b290