### PR TITLE
Tighten CTC coverage length penalty

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -184,8 +184,7 @@ ctc_loss:
     coverage:
       enabled: true
       weight: 0.12
-      min_ratio: 0.92
-      tolerance: 0.03
+      margin: 4.0
       warmup_epochs: 5
 
 alignment_regularization:
@@ -360,5 +359,5 @@ decoding:
 checkpoint_selection:
   enabled: true
   lambda_diag: 0.3
-  lambda_length: 0.2
+  lambda_length: 0.3
   target_length_diff: 0.0

--- a/README.md
+++ b/README.md
@@ -118,8 +118,7 @@ ctc_loss:
     coverage:
       enabled: true          # encourages enough non-blank mass to cover the transcript length
       weight: 0.12
-      min_ratio: 0.92
-      tolerance: 0.03        # allows slight under-coverage before the loss activates
+      margin: 4.0            # allows up to ~4 frames of under-coverage before the loss activates
 
 alignment_regularization:
   attention_duration:

--- a/Utils/run_probe_suite.py
+++ b/Utils/run_probe_suite.py
@@ -13,6 +13,7 @@ import argparse
 import concurrent.futures
 import copy
 import math
+import multiprocessing as mp
 import warnings
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence, Tuple
@@ -620,7 +621,11 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         max_workers = max(1, int(args.num_workers))
         metrics_by_epoch: Dict[int, Dict[str, float]] = {}
 
-        with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        executor_kwargs = {"max_workers": max_workers}
+        if device.type == "cuda":
+            executor_kwargs["mp_context"] = mp.get_context("spawn")
+
+        with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
             future_to_epoch = {
                 executor.submit(
                     _evaluate_epoch_checkpoint,

--- a/Utils/run_probe_suite.py
+++ b/Utils/run_probe_suite.py
@@ -626,18 +626,23 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
             executor_kwargs["mp_context"] = mp.get_context("spawn")
 
         with concurrent.futures.ProcessPoolExecutor(**executor_kwargs) as executor:
-            future_to_epoch = {
-                executor.submit(
-                    _evaluate_epoch_checkpoint,
-                    epoch_idx,
-                    str(checkpoint_file),
-                    config,
-                    device_str,
-                    args.band,
-                    args.max_align_batches,
-                ): epoch_idx
-                for epoch_idx, checkpoint_file in epoch_checkpoints
-            }
+            future_to_epoch = {}
+            for epoch_idx, checkpoint_file in epoch_checkpoints:
+                print(
+                    f"[AuxiliaryASR] dispatching evaluation for epoch {epoch_idx} "
+                    f"({checkpoint_file.name})"
+                )
+                future_to_epoch[
+                    executor.submit(
+                        _evaluate_epoch_checkpoint,
+                        epoch_idx,
+                        str(checkpoint_file),
+                        config,
+                        device_str,
+                        args.band,
+                        args.max_align_batches,
+                    )
+                ] = epoch_idx
 
             for future in concurrent.futures.as_completed(future_to_epoch):
                 epoch_idx = future_to_epoch[future]
@@ -650,7 +655,7 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
 
         for epoch_idx, checkpoint_file in epoch_checkpoints:
             metrics = metrics_by_epoch[epoch_idx]
-            print(f"=== Evaluating epoch {epoch_idx} ({checkpoint_file.name}) ===")
+            print(f"=== Results for epoch {epoch_idx} ({checkpoint_file.name}) ===")
             print(
                 "  PER: {per:.4f} | diagonal: {diag:.4f} | blank: {blank:.4f} | "
                 "len_diff: {len_diff:.4f} | p50: {p50:.4f} | J: {joint:.4f}".format(

--- a/trainer.py
+++ b/trainer.py
@@ -471,27 +471,22 @@ class Trainer(object):
             mask = mask.to(non_blank.dtype)
 
         if mask is not None:
-            coverage_mass = (non_blank * mask).sum(dim=1)
+            expected_non_blank = (non_blank * mask).sum(dim=1)
         else:
-            coverage_mass = non_blank.sum(dim=1)
+            expected_non_blank = non_blank.sum(dim=1)
+
+        margin = float(cfg.get('margin', cfg.get('delta', 4.0)))
+        margin = max(margin, 0.0)
+
+        penalty = torch.clamp((target_lengths - expected_non_blank) - margin, min=0.0)
 
         denom = target_lengths.clamp_min(1.0)
-        coverage_ratio = coverage_mass / denom
-
-        min_ratio = float(cfg.get('min_ratio', 1.0))
-        tolerance = float(cfg.get('tolerance', 0.0))
-        lower_bound = max(min_ratio - tolerance, 0.0)
-        penalty = torch.clamp(lower_bound - coverage_ratio, min=0.0)
-
-        max_ratio = cfg.get('max_ratio', None)
-        if max_ratio is not None:
-            max_ratio = float(max_ratio)
-            upper_bound = max_ratio + max(0.0, tolerance)
-            penalty = penalty + torch.clamp(coverage_ratio - upper_bound, min=0.0)
+        coverage_ratio = expected_non_blank / denom
 
         loss_value = penalty.mean() * weight
 
         stats = {
+            'diagnostics/ctc_expected_non_blank': float(expected_non_blank.mean().detach().item()),
             'diagnostics/ctc_coverage_ratio': float(coverage_ratio.mean().detach().item()),
         }
         return loss_value, stats


### PR DESCRIPTION
## Summary
- switch the CTC coverage regulariser to a hinge on the expected non-blank count with a tighter 4-frame margin
- surface the new margin setting in the default config and docs while bumping the length weighting to 0.3

## Testing
- python -m compileall trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68e4c86ad5f083329b48b0c4512e86fa