### PR TITLE
Enable monotonic chunkwise attention and retune diagonal prior

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -88,6 +88,8 @@ model_params:
    n_layers: 5
    location_kernel_size: 31
    attention_dropout: 0.1
+   attention_type: monotonic_chunkwise
+   attention_chunk_size: 4
 
 multi_task:
   use_ctc: true
@@ -160,9 +162,9 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
 diagonal_attention_prior_weight:
-  initial: 0.35
-  target: 0.65
-  warmup_epochs: 60
+  initial: 1.2
+  target: 0.25
+  warmup_epochs: 100
   hold_epochs: 20
 diagonal_attention_prior_sigma: 0.32
 

--- a/layers.py
+++ b/layers.py
@@ -152,7 +152,9 @@ class LocationLayer(nn.Module):
 class Attention(nn.Module):
     def __init__(self, attention_rnn_dim, embedding_dim, attention_dim,
                  attention_location_n_filters, attention_location_kernel_size,
-                 attention_dropout=0.0):
+                 attention_dropout=0.0,
+                 use_monotonic_chunkwise: bool = False,
+                 monotonic_chunk_size: int = 0):
         super(Attention, self).__init__()
         self.query_layer = LinearNorm(attention_rnn_dim, attention_dim,
                                       bias=False, w_init_gain='tanh')
@@ -165,6 +167,9 @@ class Attention(nn.Module):
         self.score_mask_value = -float("inf")
         self.attention_dropout_p = max(0.0, float(attention_dropout))
         self._attention_dropout = nn.Dropout(p=self.attention_dropout_p) if self.attention_dropout_p > 0.0 else None
+        chunk_size = int(monotonic_chunk_size or 0)
+        self.monotonic_chunk_size = max(0, chunk_size)
+        self.use_monotonic_chunkwise = bool(use_monotonic_chunkwise and self.monotonic_chunk_size > 0)
 
     def get_alignment_energies(self, query, processed_memory,
                                attention_weights_cat):
@@ -187,6 +192,23 @@ class Attention(nn.Module):
         energies = energies.squeeze(-1)
         return energies
 
+    def _compute_monotonic_chunk_mask(self, attention_weights_cat: torch.Tensor, max_time: int) -> torch.Tensor:
+        if not self.use_monotonic_chunkwise or max_time <= 0:
+            return None
+
+        prev_weights = attention_weights_cat[:, 0, :]
+        # Determine if any attention has been emitted previously for each batch.
+        has_history = prev_weights.sum(dim=1, keepdim=True) > 0
+        # Default to the first timestep when no history is available yet.
+        start_index = torch.argmax(prev_weights, dim=1, keepdim=True)
+        start_index = torch.where(has_history, start_index, torch.zeros_like(start_index))
+        start_index = torch.clamp(start_index, max=max_time - 1)
+        end_index = torch.clamp(start_index + self.monotonic_chunk_size, max=max_time)
+
+        positions = torch.arange(max_time, device=attention_weights_cat.device).unsqueeze(0)
+        mask = (positions < start_index) | (positions >= end_index)
+        return mask
+
     def forward(self, attention_hidden_state, memory, processed_memory,
                 attention_weights_cat, mask):
         """
@@ -200,6 +222,13 @@ class Attention(nn.Module):
         """
         alignment = self.get_alignment_energies(
             attention_hidden_state, processed_memory, attention_weights_cat)
+
+        chunk_mask = self._compute_monotonic_chunk_mask(attention_weights_cat, alignment.size(1))
+        if chunk_mask is not None:
+            if mask is None:
+                mask = chunk_mask
+            else:
+                mask = mask | chunk_mask
 
         if mask is not None:
             alignment.data.masked_fill_(mask, self.score_mask_value)

--- a/models.py
+++ b/models.py
@@ -148,6 +148,8 @@ class ASRCNN(nn.Module):
                  token_embedding_dim=256,
                  location_kernel_size=63,
                  attention_dropout=0.0,
+                 attention_type: str = "location",
+                 attention_chunk_size: int = 0,
                  multi_task_config=None,
                  stabilization_config=None,
                  memory_optimization_config=None,
@@ -267,12 +269,17 @@ class ASRCNN(nn.Module):
         else:
             self.ctc_linear = None
 
+        self.attention_type = str(attention_type or "location").lower()
+        self.attention_chunk_size = int(attention_chunk_size or 0)
+
         self.asr_s2s = ASRS2S(
             embedding_dim=token_embedding_dim,
             hidden_dim=hidden_dim//2,
             n_token=n_token,
             location_kernel_size=location_kernel_size,
-            attention_dropout=attention_dropout)
+            attention_dropout=attention_dropout,
+            attention_type=self.attention_type,
+            attention_chunk_size=self.attention_chunk_size)
 
         frame_cfg = self.multi_task_config.get('frame_phoneme', {}) or {}
         self.enable_frame_classifier = bool(frame_cfg.get('enabled', False))
@@ -688,7 +695,9 @@ class ASRS2S(nn.Module):
                  n_location_filters=32,
                  location_kernel_size=63,
                  n_token=40,
-                 attention_dropout=0.0):
+                 attention_dropout=0.0,
+                 attention_type: str = "location",
+                 attention_chunk_size: int = 0):
         super(ASRS2S, self).__init__()
         self.embedding = nn.Embedding(n_token, embedding_dim)
         val_range = math.sqrt(6 / hidden_dim)
@@ -696,13 +705,18 @@ class ASRS2S(nn.Module):
 
         self.decoder_rnn_dim = hidden_dim
         self.project_to_n_symbols = nn.Linear(self.decoder_rnn_dim, n_token)
+        attn_type = str(attention_type or "location").lower()
+        chunk_size = int(attention_chunk_size or 0)
+        use_monotonic_chunkwise = attn_type in ("monotonic_chunkwise", "mocha", "monotonic_chunk", "chunkwise")
         self.attention_layer = Attention(
             self.decoder_rnn_dim,
             hidden_dim,
             hidden_dim,
             n_location_filters,
             location_kernel_size,
-            attention_dropout=attention_dropout
+            attention_dropout=attention_dropout,
+            use_monotonic_chunkwise=use_monotonic_chunkwise,
+            monotonic_chunk_size=chunk_size if use_monotonic_chunkwise else 0
         )
         self.decoder_rnn = nn.LSTMCell(self.decoder_rnn_dim + embedding_dim, self.decoder_rnn_dim)
         self.project_to_hidden = nn.Sequential(


### PR DESCRIPTION
## Summary
- add configuration knobs to switch the decoder to monotonic chunkwise attention with a chunk size of 4
- wire the model to honour the new attention settings and mask attention scores outside the active chunk
- lengthen the guided-attention warm-up window and update its weights in the default configuration

## Testing
- python -m compileall models.py layers.py Configs/config.yml

------
https://chatgpt.com/codex/tasks/task_e_68e4dd298db88332821d5e0323950441