### PR TITLE
Adjust diagonal prior schedule and attention dropout defaults

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -160,9 +160,9 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
 diagonal_attention_prior_weight:
-  initial: 0.35
-  target: 0.65
-  warmup_epochs: 60
+  initial: 1.2
+  target: 0.25
+  warmup_epochs: 100  # 40% of the planned 250 training epochs
   hold_epochs: 20
 diagonal_attention_prior_sigma: 0.32
 

--- a/models.py
+++ b/models.py
@@ -147,7 +147,7 @@ class ASRCNN(nn.Module):
                  n_layers=6,
                  token_embedding_dim=256,
                  location_kernel_size=63,
-                 attention_dropout=0.0,
+                 attention_dropout=0.1,
                  multi_task_config=None,
                  stabilization_config=None,
                  memory_optimization_config=None,
@@ -688,7 +688,7 @@ class ASRS2S(nn.Module):
                  n_location_filters=32,
                  location_kernel_size=63,
                  n_token=40,
-                 attention_dropout=0.0):
+                 attention_dropout=0.1):
         super(ASRS2S, self).__init__()
         self.embedding = nn.Embedding(n_token, embedding_dim)
         val_range = math.sqrt(6 / hidden_dim)


### PR DESCRIPTION
## Summary
- extend the diagonal attention prior warm window to 40% of training and update the guided-attention weight schedule to 1.2→0.25
- default the encoder–decoder and cross-attention modules to use 0.1 attention dropout so every attention block benefits from dropout

## Testing
- python -m compileall models.py trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ebd23174833289890a9ca37c6ced