### PR TITLE
Retune diagonal attention prior schedule

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -160,11 +160,11 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
 diagonal_attention_prior_weight:
-  initial: 0.35
-  target: 0.65
-  warmup_epochs: 60
+  initial: 1.2
+  target: 0.25
+  warmup_epochs: 100  # ~40% of the 250 scheduled epochs
   hold_epochs: 20
-diagonal_attention_prior_sigma: 0.32
+diagonal_attention_prior_sigma: 0.3
 
 # stabilizes ASR training for smaller datasets
 entropy_params:


### PR DESCRIPTION
## Summary
- extend the diagonal attention warm window to cover 40% of training while adjusting the schedule to decay from 1.2 to 0.25
- narrow the diagonal prior sigma to 0.3 to encourage tighter alignments

## Testing
- python -m compileall Configs/config.yml models.py trainer.py utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ebd23174833289890a9ca37c6ced