### PR TITLE
Add lightweight guided attention helper schedule

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -160,11 +160,11 @@ sortagrad_switch_to_shuffled_dataset_epoch: 10
 # make ASR learn to read phonemes from left to right, not randomly
 use_diagonal_attention_prior: True
 diagonal_attention_prior_weight:
-  initial: 1.2
-  target: 0.25
-  warmup_epochs: 100  # ~40% of the 250 scheduled epochs
-  hold_epochs: 20
-diagonal_attention_prior_sigma: 0.3
+  initial: 0.05
+  target: 0.02
+  hold_steps: 4000  # keep the helper active for ~3-5k optimiser steps
+  warmup_steps: 0
+diagonal_attention_prior_sigma: 0.25
 
 # stabilizes ASR training for smaller datasets
 entropy_params:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ decoding:
     insertion_bonus: 0.05   # encourages emitting non-blank symbols when hypotheses compete
 ```
 
-Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and is scheduled via `diagonal_attention_prior_weight` so it ramps from a moderate early weight to a stronger late-epoch value. Coupled with the duration regulariser above, this keeps alignments monotonic while ensuring each phoneme retains a multi-frame footprint.
+Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and uses a tiny guided-attention helper for the first few thousand optimiser steps. By default the helper holds a λ of 0.05 for the first ~4k steps before settling to 0.02 with a narrower σ≈0.25 along the normalised axes. This gentle schedule nudges early monotonicity without undoing the coverage and blank-rate regularisers; if you notice diagonal coherence dropping (e.g., due to a masking bug), simply disable the prior by setting `use_diagonal_attention_prior` to `False`.
 
 To avoid choosing checkpoints that only excel at PER while misaligning attention or dropping symbols, training now logs a joint selection score that blends PER, diagonal coherence, and the normalised CTC length gap. The configuration exposes the coefficients under `checkpoint_selection` and the trainer will keep a `best_joint.pth` symlink pointing at the most alignment-friendly checkpoint observed so far.
 

--- a/trainer.py
+++ b/trainer.py
@@ -283,14 +283,26 @@ class Trainer(object):
         if isinstance(weight_config, dict):
             initial = float(weight_config.get('initial', weight_config.get('base', weight_config.get('start', 0.0))))
             target = float(weight_config.get('target', weight_config.get('final', initial)))
-            warmup = int(weight_config.get('warmup_epochs', weight_config.get('ramp_epochs', 0)))
-            hold = int(weight_config.get('hold_epochs', 0))
+            warmup_epochs = int(weight_config.get('warmup_epochs', weight_config.get('ramp_epochs', 0)))
+            hold_epochs = int(weight_config.get('hold_epochs', 0))
+            warmup_steps = int(weight_config.get('warmup_steps', weight_config.get('ramp_steps', 0)))
+            hold_steps = int(weight_config.get('hold_steps', weight_config.get('initial_steps', 0)))
+
             schedule = {
                 'initial': initial,
                 'target': target,
-                'warmup': max(0, warmup),
-                'hold': max(0, hold),
+                'warmup_epochs': max(0, warmup_epochs),
+                'hold_epochs': max(0, hold_epochs),
+                'warmup_steps': max(0, warmup_steps),
+                'hold_steps': max(0, hold_steps),
             }
+
+            # Default to a step-based schedule if any step-related parameter is set.
+            if schedule['warmup_steps'] > 0 or schedule['hold_steps'] > 0:
+                schedule['mode'] = 'step'
+            else:
+                schedule['mode'] = 'epoch'
+
             base_weight = initial
         else:
             base_weight = float(weight_config) if weight_config is not None else 0.0
@@ -299,24 +311,47 @@ class Trainer(object):
         self.diagonal_attention_weight_schedule = schedule
         self._active_diagonal_attention_weight = float(base_weight)
 
-    def _current_diagonal_attention_weight(self, epoch_index: int) -> float:
+    def _current_diagonal_attention_weight(self, training: bool) -> float:
         schedule = self.diagonal_attention_weight_schedule
         if not schedule:
             return float(self.diagonal_attention_prior_weight)
 
-        epoch = max(1, int(epoch_index))
         initial = float(schedule['initial'])
         target = float(schedule['target'])
-        warmup = int(schedule['warmup'])
-        hold = int(schedule['hold'])
+        mode = schedule.get('mode', 'epoch')
 
-        if warmup <= 0:
+        if mode == 'step':
+            if training:
+                step_index = self._optimizer_step_count + 1
+            else:
+                step_index = max(1, self._optimizer_step_count)
+
+            hold_steps = int(schedule.get('hold_steps', 0))
+            warmup_steps = int(schedule.get('warmup_steps', 0))
+
+            if hold_steps > 0 and step_index <= hold_steps:
+                weight = initial
+            else:
+                if warmup_steps <= 0:
+                    weight = target
+                else:
+                    progress_steps = max(0, step_index - hold_steps)
+                    progress = min(1.0, progress_steps / float(max(1, warmup_steps)))
+                    weight = initial + (target - initial) * progress
+
+            return float(weight)
+
+        epoch_index = self.epochs + 1 if training else max(1, self.epochs)
+        warmup_epochs = int(schedule.get('warmup_epochs', 0))
+        hold_epochs = int(schedule.get('hold_epochs', 0))
+
+        if warmup_epochs <= 0:
             weight = target
         else:
-            progress = min(1.0, max(0.0, (epoch - 1) / float(max(1, warmup))))
+            progress = min(1.0, max(0.0, (epoch_index - 1) / float(max(1, warmup_epochs))))
             weight = initial + (target - initial) * progress
 
-        if epoch > warmup + hold:
+        if epoch_index > warmup_epochs + hold_epochs:
             weight = target
 
         return float(weight)
@@ -326,12 +361,7 @@ class Trainer(object):
             self._active_diagonal_attention_weight = 0.0
             return
 
-        if training:
-            epoch_index = self.epochs + 1
-        else:
-            epoch_index = max(1, self.epochs)
-
-        weight = self._current_diagonal_attention_weight(epoch_index)
+        weight = self._current_diagonal_attention_weight(training=training)
         self._active_diagonal_attention_weight = weight
 
     def _get_active_diagonal_attention_weight(self) -> float:
@@ -1624,6 +1654,7 @@ class Trainer(object):
                     losses.update(duration_stats)
 
             if self.use_diagonal_attention_prior and s2s_attn is not None:
+                self._set_active_diagonal_attention_weight(training=self.model.training)
                 diag_weight = self._get_active_diagonal_attention_weight()
                 if diag_weight > 0.0:
                     loss_diagonal = diagonal_attention_prior(


### PR DESCRIPTION
## Summary
- add support for step-aware diagonal attention weight schedules and refresh the guided-attention helper defaults
- lower the diagonal prior sigma and document the small helper strategy for early training

## Testing
- python -m compileall trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68e565b2cadc8332a3ce699c60a38bd9