### PR TITLE
Tighten coverage regulariser with temporal smoothing

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -195,6 +195,7 @@ ctc_loss:
     coverage:
       enabled: true
       weight: 0.12
+      tv_weight: 0.3
       margin: 3.0
       locked_weight: 0.25
       locked_margin: 0.0

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ ctc_loss:
     coverage:
       enabled: true          # encourages enough non-blank mass to cover the transcript length
       weight: 0.12
+      tv_weight: 0.3         # stronger temporal smoothing on the non-blank posterior mass
       margin: 3.0            # allows up to ~3 frames of under-coverage before the loss activates
       locked_weight: 0.25    # gentler overshoot damping once coverage has caught up
       locked_margin: 0.0     # optional extra slack before the overshoot term activates
@@ -149,6 +150,8 @@ regularization:
 ```
 
 All of the auxiliary losses honour a `warmup_epochs` key (`5` for the CTC penalties and `8` for the duration term in the default config) so you can delay their activation until the alignment has roughly converged.
+
+The coverage helper now applies a locally normalised hinge along with a heavier total-variation prior over the non-blank posterior mass. This combination pushes token durations to recover sooner while keeping adjacent timesteps smooth enough to avoid 1-frame spikes.
 
 Decoding-time safeguards provide gentler blank suppression without distorting training. The beam-search configuration supports a temperature, blank penalty, insertion bonus, and lightweight length normalisation:
 

--- a/trainer.py
+++ b/trainer.py
@@ -785,14 +785,48 @@ class Trainer(object):
             baseline = math.log(2.0) * locked_softness
             overshoot = (softened - baseline).clamp_min(0.0)
 
-        penalty = shortfall
+        denom_lengths = target_lengths.clamp_min(1.0)
+
+        penalty = shortfall / denom_lengths
         if locked_weight > 0.0:
-            penalty = penalty + locked_weight * overshoot
+            penalty = penalty + locked_weight * (overshoot / denom_lengths)
 
         denom = target_lengths.clamp_min(1.0)
         coverage_ratio = expected_non_blank / denom
 
-        loss_value = penalty.mean() * weight
+        coverage_term = penalty.mean()
+
+        tv_weight = float(cfg.get('tv_weight', cfg.get('lambda_tv', 0.0)))
+        tv_weight = max(0.0, tv_weight)
+        tv_loss = None
+        if tv_weight > 0.0 and probs.dim() == 3 and probs.size(1) > 1:
+            non_blank_probs = probs.clone()
+            if 0 <= blank_id < non_blank_probs.size(-1):
+                non_blank_probs[..., blank_id] = 0.0
+
+            diffs = non_blank_probs[:, 1:, :] - non_blank_probs[:, :-1, :]
+            diffs = diffs.abs().sum(dim=2)
+
+            if mask is not None:
+                pair_mask = (mask[:, 1:] > 0) & (mask[:, :-1] > 0)
+                pair_mask = pair_mask.to(diffs.dtype)
+                diffs = diffs * pair_mask
+                pair_counts = pair_mask.sum(dim=1)
+            else:
+                pair_counts = torch.full(
+                    (diffs.size(0),),
+                    diffs.size(1),
+                    device=diffs.device,
+                    dtype=diffs.dtype,
+                )
+
+            pair_counts = pair_counts.clamp_min(1.0)
+            tv_per_sample = diffs.sum(dim=1) / pair_counts
+            tv_loss = tv_per_sample.mean()
+        else:
+            tv_loss = torch.tensor(0.0, device=probs.device, dtype=probs.dtype)
+
+        loss_value = weight * coverage_term + tv_weight * tv_loss
 
         stats = {
             'diagnostics/ctc_expected_non_blank': float(expected_non_blank.mean().detach().item()),
@@ -808,6 +842,9 @@ class Trainer(object):
                 stats['diagnostics/ctc_coverage_locked_ratio'] = float(
                     overshoot_mask.float().mean().detach().item()
                 )
+        if tv_weight > 0.0 and tv_loss is not None:
+            stats['diagnostics/ctc_temporal_tv'] = float(tv_loss.detach().item())
+            stats['diagnostics/ctc_temporal_tv_weight'] = float(tv_weight)
         return loss_value, stats
 
     def _compute_attention_duration_regularization(self, attn, text_lengths, mel_lengths):


### PR DESCRIPTION
## Summary
- normalise the CTC coverage penalty by token length and blend in a heavier temporal TV prior on non-blank posteriors
- expose the stronger smoothing weight in the default config and document the updated behaviour in the README

## Testing
- python -m compileall trainer.py

------
https://chatgpt.com/codex/tasks/task_e_68e627a0185c8332960380cfd508026b