### PR TITLE
Add adaptive alignment monitor for cross-lingual ASR

### DIFF
--- a/Configs/config.yml
+++ b/Configs/config.yml
@@ -212,6 +212,36 @@ alignment_regularization:
     tolerance: 0.3
     warmup_epochs: 8
 
+alignment_health_monitor:
+  enabled: true
+  attention_duration:
+    metric: "diagnostics/attn_duration_p50"
+    target: 2.0
+    tolerance: 0.1
+    patience: 2
+    min_epoch: 6
+    cooldown: 3
+    boost:
+      attention_weight: 0.05
+      max_attention_weight: 0.35
+      diag_weight: 0.01
+      max_diag_weight: 0.12
+      blank_target_shift: -0.02
+      min_blank_target: 0.48
+      max_blank_target: 0.72
+  diagonal_coherence:
+    metric: "eval/diag_coherence"
+    target: 0.35
+    tolerance: 0.03
+    patience: 2
+    min_epoch: 5
+    cooldown: 2
+    boost:
+      diag_weight: 0.02
+      max_diag_weight: 0.15
+      sigma_decay: 0.02
+      min_sigma: 0.18
+
 dataset_params:
   # SpecAugment parameters applied only on the training split.
   spec_augment:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,31 @@ decoding:
 
 Additionally, the diagonal attention prior now masks out padded timesteps, applies a light dropout (configurable through `model_params.attention_dropout`), and uses a tiny guided-attention helper for the first few thousand optimiser steps. By default the helper holds a λ of 0.05 for the first ~4k steps before settling to 0.02 with a narrower σ≈0.25 along the normalised axes. This gentle schedule nudges early monotonicity without undoing the coverage and blank-rate regularisers; if you notice diagonal coherence dropping (e.g., due to a masking bug), simply disable the prior by setting `use_diagonal_attention_prior` to `False`.
 
+### Automatic alignment health monitor
+
+Cross-lingual corpora sometimes exhibit very different speaking rates or phonotactics. When the auxiliary losses are tuned on one language it is easy for another to collapse into one-frame spikes (median attention duration near 1) or for the attention maps to drift off the diagonal. To keep the model stable without micro-managing the config, the trainer now exposes an `alignment_health_monitor` block (enabled by default). On each evaluation pass the monitor inspects metrics such as `diagnostics/attn_duration_p50` and `eval/diag_coherence`; if they fall below their targets for a few validations in a row it automatically increases the attention-duration penalty, boosts the diagonal prior, narrows the prior’s σ, and gently lowers the target CTC blank-rate. The boosts respect configurable ceilings so mature languages stay untouched while harder corpora (e.g., dense Arabic datasets) quickly recover p50 ≥ 2.0 without manual restarts.
+
+The default thresholds are conservative, but you can tune the patience, cooldown, and boost magnitudes in `Configs/config.yml`:
+
+```yaml
+alignment_health_monitor:
+  enabled: true
+  attention_duration:
+    target: 2.0
+    tolerance: 0.1
+    boost:
+      attention_weight: 0.05   # increase duration penalty in 0.05 steps up to 0.35
+      diag_weight: 0.01         # gently strengthen the guided-attention helper
+      blank_target_shift: -0.02 # lower the blank-rate target to curb deletions
+  diagonal_coherence:
+    target: 0.35
+    boost:
+      diag_weight: 0.02
+      sigma_decay: 0.02        # tighten the diagonal prior when attention drifts
+```
+
+Disable the entire block (or individual subsections) if you prefer to manage the hyperparameters manually.
+
 To avoid choosing checkpoints that only excel at PER while misaligning attention or dropping symbols, training now logs a joint selection score that blends PER, diagonal coherence, and the normalised CTC length gap. The configuration exposes the coefficients under `checkpoint_selection` and the trainer will keep a `best_joint.pth` symlink pointing at the most alignment-friendly checkpoint observed so far.
 
 ```yaml

--- a/train.py
+++ b/train.py
@@ -1332,6 +1332,10 @@ def main(config_path):
         results = train_results.copy()
         results.update(eval_results)
 
+        alignment_updates = trainer.apply_alignment_health_policies(results)
+        if alignment_updates:
+            results.update(alignment_updates)
+
         p50_metric = results.get('diagnostics/attn_duration_p50')
         current_optimizer_step = trainer._get_optimizer_step_count()
         lambda_updated = _maybe_update_lambda_length(p50_metric, current_optimizer_step)

--- a/trainer.py
+++ b/trainer.py
@@ -131,6 +131,12 @@ class Trainer(object):
             blank_reg_cfg = {}
         self.ctc_blank_rate_regularization_enabled = bool(blank_reg_cfg.get('enabled', False))
         self.ctc_blank_rate_regularization_config = self._configure_ctc_blank_rate_regularization(blank_reg_cfg)
+        self.ctc_blank_rate_base_target = float(
+            self.ctc_blank_rate_regularization_config.get('_base_target', 0.65)
+        )
+        self._alignment_blank_target_shift = 0.0
+        self._alignment_blank_target_min = None
+        self._alignment_blank_target_max = None
 
         coverage_reg_cfg = ctc_reg_cfg.get('coverage', {}) or {}
         if not isinstance(coverage_reg_cfg, dict):
@@ -147,8 +153,14 @@ class Trainer(object):
         attn_duration_cfg = alignment_reg_cfg.get('attention_duration', {}) or {}
         if not isinstance(attn_duration_cfg, dict):
             attn_duration_cfg = {}
+        else:
+            attn_duration_cfg = dict(attn_duration_cfg)
+        base_attn_weight = float(attn_duration_cfg.get('weight', 0.0))
+        attn_duration_cfg.setdefault('_base_weight', base_attn_weight)
+        self.attention_duration_base_weight = base_attn_weight
         self.attention_duration_regularization_enabled = bool(attn_duration_cfg.get('enabled', False))
         self.attention_duration_regularization_config = attn_duration_cfg
+        self._alignment_duration_boost = 0.0
 
         self.mixspeech_config = mixspeech_config or {}
         self.mixspeech_enabled = bool(self.mixspeech_config.get('enabled', False))
@@ -177,6 +189,16 @@ class Trainer(object):
         self.entropy_regularization_eps = float(entropy_cfg.get('eps', 1.0e-6))
         targets_cfg = entropy_cfg.get('targets', {}) if isinstance(entropy_cfg, dict) else {}
         self.entropy_regularization_targets = self._parse_entropy_regularization_targets(targets_cfg, entropy_cfg)
+
+        health_cfg = {}
+        if isinstance(self.config, dict):
+            health_cfg = self.config.get('alignment_health_monitor', {}) or {}
+            if not isinstance(health_cfg, dict):
+                health_cfg = {}
+        self.alignment_health_monitor_enabled = bool(health_cfg.get('enabled', False))
+        self.alignment_health_monitor_config = health_cfg
+        self._alignment_diag_boost = 0.0
+        self._alignment_health_state = self._init_alignment_health_state()
 
         memopt_cfg = memory_optimization_config or {}
         if not isinstance(memopt_cfg, dict):
@@ -362,7 +384,8 @@ class Trainer(object):
             return
 
         weight = self._current_diagonal_attention_weight(training=training)
-        self._active_diagonal_attention_weight = weight
+        weight = weight + float(getattr(self, '_alignment_diag_boost', 0.0))
+        self._active_diagonal_attention_weight = max(0.0, weight)
 
     def _get_active_diagonal_attention_weight(self) -> float:
         return float(getattr(self, '_active_diagonal_attention_weight', self.diagonal_attention_prior_weight))
@@ -505,7 +528,27 @@ class Trainer(object):
         config['_base_weight'] = base_weight
         config['_raw_weight'] = weight_cfg
         config['weight'] = base_weight
+        try:
+            base_target = float(config.get('target', config.get('target_blank_rate', 0.65)))
+        except (TypeError, ValueError):
+            base_target = 0.65
+        config['_base_target'] = base_target
+        config['target'] = base_target
+        config['target_blank_rate'] = base_target
         return config
+
+    def _init_alignment_health_state(self):
+        state = {}
+        monitor_cfg = self.alignment_health_monitor_config
+        if not isinstance(monitor_cfg, dict):
+            return state
+
+        for key in ('attention_duration', 'diagonal_coherence'):
+            section = monitor_cfg.get(key)
+            if isinstance(section, dict) and section:
+                state[key] = {'violations': 0, 'cooldown': 0}
+
+        return state
 
     def _current_ctc_blank_rate_weight(self, training: bool) -> float:
         cfg = self.ctc_blank_rate_regularization_config or {}
@@ -555,6 +598,29 @@ class Trainer(object):
                 weight = target
 
         return float(max(0.0, weight))
+
+    def _get_ctc_blank_rate_target(self) -> float:
+        cfg = self.ctc_blank_rate_regularization_config or {}
+        base_target = cfg.get('_base_target', cfg.get('target', cfg.get('target_blank_rate', 0.65)))
+        try:
+            base_value = float(base_target)
+        except (TypeError, ValueError):
+            base_value = 0.65
+
+        shift = float(getattr(self, '_alignment_blank_target_shift', 0.0))
+        min_target = getattr(self, '_alignment_blank_target_min', None)
+        max_target = getattr(self, '_alignment_blank_target_max', None)
+        if min_target is None:
+            min_target = 0.0
+        if max_target is None:
+            max_target = 0.95
+
+        target = base_value + shift
+        target = max(min_target, min(max_target, target))
+
+        cfg['target'] = target
+        cfg['target_blank_rate'] = target
+        return target
 
     def _current_ctc_blank_scale(self, epoch_index: int) -> float:
         if not self._ctc_blank_scale_enabled:
@@ -709,7 +775,7 @@ class Trainer(object):
         else:
             blank_rate = blank_probs.mean(dim=1)
 
-        target = float(cfg.get('target', cfg.get('target_blank_rate', 0.65)))
+        target = float(self._get_ctc_blank_rate_target())
         tolerance = float(cfg.get('tolerance', 0.0))
         upper = min(max(target + tolerance, 0.0), 1.0)
         lower = max(min(target - tolerance, 1.0), 0.0)
@@ -780,6 +846,8 @@ class Trainer(object):
         stats = {
             'diagnostics/ctc_blank_rate': float(blank_rate.mean().detach().item()),
             'diagnostics/ctc_blank_rate_weight': float(weight),
+            'diagnostics/ctc_blank_target': float(target),
+            'diagnostics/ctc_blank_target_shift': float(getattr(self, '_alignment_blank_target_shift', 0.0)),
         }
         if blank_run_penalty is not None:
             stats.update({
@@ -907,6 +975,24 @@ class Trainer(object):
             stats['diagnostics/ctc_temporal_tv_weight'] = float(tv_weight)
         return loss_value, stats
 
+    def _get_base_attention_duration_weight(self) -> float:
+        cfg = self.attention_duration_regularization_config or {}
+        base = cfg.get('_base_weight', cfg.get('weight', 0.0))
+        try:
+            return float(base)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _get_attention_duration_weight(self) -> float:
+        base = self._get_base_attention_duration_weight()
+        boost = float(getattr(self, '_alignment_duration_boost', 0.0))
+        weight = base + boost
+        if weight < 0.0:
+            weight = 0.0
+        cfg = self.attention_duration_regularization_config or {}
+        cfg['weight'] = weight
+        return weight
+
     def _compute_attention_duration_regularization(self, attn, text_lengths, mel_lengths):
         if not self.attention_duration_regularization_enabled:
             return None
@@ -915,7 +1001,7 @@ class Trainer(object):
         if not self._alignment_regularization_warmup_passed(cfg):
             return None
 
-        weight = float(cfg.get('weight', 0.0))
+        weight = self._get_attention_duration_weight()
         if weight == 0.0:
             return None
 
@@ -966,6 +1052,8 @@ class Trainer(object):
             short_ratio = short_mask.float().sum() / denom
             stats['diagnostics/attn_duration_short_ratio'] = float(short_ratio.item())
 
+        stats['diagnostics/attn_duration_weight'] = float(weight)
+        stats['diagnostics/attn_duration_boost'] = float(getattr(self, '_alignment_duration_boost', 0.0))
         return loss_value, stats
 
     def _compute_ctc_expected_durations(self, logits, input_lengths, tokens, token_lengths):
@@ -1040,6 +1128,224 @@ class Trainer(object):
             return max(int(getattr(self.optimizer, "_step_count", 0)), 0)
         except (TypeError, ValueError):
             return 0
+
+    def apply_alignment_health_policies(self, metrics):
+        adjustments = {}
+        if not self.alignment_health_monitor_enabled:
+            return adjustments
+        if not isinstance(metrics, dict):
+            return adjustments
+
+        def _lookup_metric(name):
+            if not name:
+                return None
+            if name in metrics:
+                return metrics[name]
+            if isinstance(name, str):
+                if name.startswith('eval/'):
+                    alt = name.replace('eval/', 'diagnostics/', 1)
+                    if alt in metrics:
+                        return metrics[alt]
+                elif name.startswith('diagnostics/'):
+                    alt = name.replace('diagnostics/', 'eval/', 1)
+                    if alt in metrics:
+                        return metrics[alt]
+            return None
+
+        epoch_index = max(1, int(self.epochs))
+
+        monitor_cfg = self.alignment_health_monitor_config
+        if not isinstance(monitor_cfg, dict):
+            return adjustments
+
+        # Attention duration monitor
+        attn_cfg = monitor_cfg.get('attention_duration') if monitor_cfg else None
+        if isinstance(attn_cfg, dict) and attn_cfg:
+            state = self._alignment_health_state.setdefault(
+                'attention_duration', {'violations': 0, 'cooldown': 0}
+            )
+            metric_name = attn_cfg.get('metric', 'diagnostics/attn_duration_p50')
+            metric_value = _lookup_metric(metric_name)
+            try:
+                metric_value = float(metric_value)
+            except (TypeError, ValueError):
+                metric_value = None
+
+            if metric_value is None or not math.isfinite(metric_value):
+                state['violations'] = 0
+            else:
+                target = float(attn_cfg.get('target', 2.0))
+                tolerance = float(attn_cfg.get('tolerance', 0.0))
+                threshold = target - tolerance
+                violation = metric_value < threshold
+                if violation:
+                    state['violations'] = state.get('violations', 0) + 1
+                else:
+                    state['violations'] = 0
+
+                cooldown_remaining = max(0, int(state.get('cooldown', 0)))
+                if cooldown_remaining > 0:
+                    state['cooldown'] = cooldown_remaining - 1
+                patience = max(1, int(attn_cfg.get('patience', 1)))
+                min_epoch = int(attn_cfg.get('min_epoch', 0))
+                ready = (
+                    violation
+                    and state['violations'] >= patience
+                    and epoch_index >= max(1, min_epoch)
+                    and cooldown_remaining == 0
+                )
+
+                if ready:
+                    state['violations'] = 0
+                    state['cooldown'] = max(0, int(attn_cfg.get('cooldown', 0)))
+                    boost_cfg = attn_cfg.get('boost', {}) or {}
+                    applied_msgs = []
+
+                    attn_boost = float(boost_cfg.get('attention_weight', 0.0))
+                    if attn_boost != 0.0:
+                        base_weight = self._get_base_attention_duration_weight()
+                        current_boost = float(getattr(self, '_alignment_duration_boost', 0.0))
+                        target_weight = base_weight + current_boost + attn_boost
+                        max_weight = float(boost_cfg.get('max_attention_weight', 0.0))
+                        if max_weight > 0.0:
+                            target_weight = min(max_weight, target_weight)
+                        new_boost = max(0.0, target_weight - base_weight)
+                        if not math.isclose(new_boost, current_boost, rel_tol=1e-6, abs_tol=1e-6):
+                            self._alignment_duration_boost = new_boost
+                            new_weight = self._get_attention_duration_weight()
+                            adjustments['alignment/attn_duration_weight'] = new_weight
+                            adjustments['alignment/attn_duration_epoch'] = float(epoch_index)
+                            adjustments['alignment/attn_duration_metric'] = float(metric_value)
+                            applied_msgs.append(f"duration_weight→{new_weight:.3f}")
+
+                    diag_boost = float(boost_cfg.get('diag_weight', 0.0))
+                    if diag_boost != 0.0:
+                        base_diag = self._current_diagonal_attention_weight(training=False)
+                        current_diag_boost = float(getattr(self, '_alignment_diag_boost', 0.0))
+                        target_diag = base_diag + current_diag_boost + diag_boost
+                        max_diag = float(boost_cfg.get('max_diag_weight', 0.0))
+                        if max_diag > 0.0:
+                            target_diag = min(max_diag, target_diag)
+                        new_diag_boost = max(0.0, target_diag - base_diag)
+                        if not math.isclose(new_diag_boost, current_diag_boost, rel_tol=1e-6, abs_tol=1e-6):
+                            self._alignment_diag_boost = new_diag_boost
+                            self._set_active_diagonal_attention_weight(training=False)
+                            new_diag_weight = self._get_active_diagonal_attention_weight()
+                            adjustments['alignment/diag_weight'] = new_diag_weight
+                            applied_msgs.append(f"diag_weight→{new_diag_weight:.3f}")
+
+                    blank_shift = float(boost_cfg.get('blank_target_shift', 0.0))
+                    if blank_shift != 0.0 and self.ctc_blank_rate_regularization_enabled:
+                        base_shift = float(getattr(self, '_alignment_blank_target_shift', 0.0))
+                        base_target = float(getattr(self, 'ctc_blank_rate_base_target', 0.65))
+                        desired_target = base_target + base_shift + blank_shift
+                        if 'min_blank_target' in boost_cfg:
+                            self._alignment_blank_target_min = float(boost_cfg['min_blank_target'])
+                            desired_target = max(self._alignment_blank_target_min, desired_target)
+                        if 'max_blank_target' in boost_cfg:
+                            self._alignment_blank_target_max = float(boost_cfg['max_blank_target'])
+                            desired_target = min(self._alignment_blank_target_max, desired_target)
+                        new_shift = desired_target - base_target
+                        if not math.isclose(new_shift, base_shift, rel_tol=1e-6, abs_tol=1e-6):
+                            self._alignment_blank_target_shift = new_shift
+                            new_target = self._get_ctc_blank_rate_target()
+                            adjustments['alignment/ctc_blank_target'] = new_target
+                            applied_msgs.append(f"blank_target→{new_target:.3f}")
+
+                    if applied_msgs:
+                        message = ", ".join(applied_msgs)
+                        self.logger.info(
+                            "[AlignmentHealth] Attention-duration boost at epoch %d: %s (metric %.3f)",
+                            epoch_index,
+                            message,
+                            metric_value,
+                        )
+
+        # Diagonal coherence monitor
+        diag_cfg = monitor_cfg.get('diagonal_coherence') if monitor_cfg else None
+        if isinstance(diag_cfg, dict) and diag_cfg:
+            state = self._alignment_health_state.setdefault(
+                'diagonal_coherence', {'violations': 0, 'cooldown': 0}
+            )
+            metric_name = diag_cfg.get('metric', 'eval/diag_coherence')
+            metric_value = _lookup_metric(metric_name)
+            try:
+                metric_value = float(metric_value)
+            except (TypeError, ValueError):
+                metric_value = None
+
+            if metric_value is None or not math.isfinite(metric_value):
+                state['violations'] = 0
+            else:
+                target = float(diag_cfg.get('target', 0.35))
+                tolerance = float(diag_cfg.get('tolerance', 0.0))
+                threshold = target - tolerance
+                violation = metric_value < threshold
+                if violation:
+                    state['violations'] = state.get('violations', 0) + 1
+                else:
+                    state['violations'] = 0
+
+                cooldown_remaining = max(0, int(state.get('cooldown', 0)))
+                if cooldown_remaining > 0:
+                    state['cooldown'] = cooldown_remaining - 1
+                patience = max(1, int(diag_cfg.get('patience', 1)))
+                min_epoch = int(diag_cfg.get('min_epoch', 0))
+                ready = (
+                    violation
+                    and state['violations'] >= patience
+                    and epoch_index >= max(1, min_epoch)
+                    and cooldown_remaining == 0
+                )
+
+                if ready:
+                    state['violations'] = 0
+                    state['cooldown'] = max(0, int(diag_cfg.get('cooldown', 0)))
+                    boost_cfg = diag_cfg.get('boost', {}) or {}
+                    applied_msgs = []
+
+                    diag_boost = float(boost_cfg.get('diag_weight', 0.0))
+                    if diag_boost != 0.0:
+                        base_diag = self._current_diagonal_attention_weight(training=False)
+                        current_diag_boost = float(getattr(self, '_alignment_diag_boost', 0.0))
+                        target_diag = base_diag + current_diag_boost + diag_boost
+                        max_diag = float(boost_cfg.get('max_diag_weight', 0.0))
+                        if max_diag > 0.0:
+                            target_diag = min(max_diag, target_diag)
+                        new_diag_boost = max(0.0, target_diag - base_diag)
+                        if not math.isclose(new_diag_boost, current_diag_boost, rel_tol=1e-6, abs_tol=1e-6):
+                            self._alignment_diag_boost = new_diag_boost
+                            self._set_active_diagonal_attention_weight(training=False)
+                            new_weight = self._get_active_diagonal_attention_weight()
+                            adjustments['alignment/diag_weight'] = new_weight
+                            applied_msgs.append(f"diag_weight→{new_weight:.3f}")
+
+                    sigma_decay = float(boost_cfg.get('sigma_decay', 0.0))
+                    if sigma_decay > 0.0:
+                        min_sigma = float(boost_cfg.get('min_sigma', 0.0))
+                        new_sigma = max(min_sigma, self.diagonal_attention_prior_sigma - sigma_decay)
+                        if not math.isclose(
+                            new_sigma,
+                            self.diagonal_attention_prior_sigma,
+                            rel_tol=1e-6,
+                            abs_tol=1e-6,
+                        ):
+                            self.diagonal_attention_prior_sigma = new_sigma
+                            adjustments['alignment/diag_sigma'] = new_sigma
+                            applied_msgs.append(f"sigma→{new_sigma:.3f}")
+
+                    if applied_msgs:
+                        message = ", ".join(applied_msgs)
+                        self.logger.info(
+                            "[AlignmentHealth] Diagonal-coherence boost at epoch %d: %s (metric %.3f)",
+                            epoch_index,
+                            message,
+                            metric_value,
+                        )
+                        adjustments['alignment/diag_metric'] = float(metric_value)
+                        adjustments['alignment/diag_epoch'] = float(epoch_index)
+
+        return adjustments
 
     def update_dataloaders(
         self,
@@ -1943,6 +2249,9 @@ class Trainer(object):
 
         train_losses = {key: np.mean(value) for key, value in train_losses.items()}
         train_losses.setdefault('train/ctc_blank_scale', self._get_active_ctc_blank_scale())
+        train_losses.setdefault('train/diag_weight', self._get_active_diagonal_attention_weight())
+        train_losses.setdefault('train/attn_duration_weight', self._get_attention_duration_weight())
+        train_losses.setdefault('train/ctc_blank_target', self._get_ctc_blank_rate_target())
         train_losses['train/learning_rate'] = self._get_lr()
         self.epochs += 1
 
@@ -2229,6 +2538,8 @@ class Trainer(object):
         eval_losses = {key: np.mean(value) for key, value in eval_losses.items()}
         eval_losses.setdefault('eval/diag_weight', self._get_active_diagonal_attention_weight())
         eval_losses.setdefault('eval/ctc_blank_scale', self._get_active_ctc_blank_scale())
+        eval_losses.setdefault('eval/attn_duration_weight', self._get_attention_duration_weight())
+        eval_losses.setdefault('eval/ctc_blank_target', self._get_ctc_blank_rate_target())
         eval_losses.update(eval_images)
         for key in list(eval_losses.keys()):
             if key.startswith('eval/image'):

--- a/trainer.py
+++ b/trainer.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import math
+import copy
 import os
 import os.path as osp
 import sys
@@ -549,6 +550,124 @@ class Trainer(object):
                 state[key] = {'violations': 0, 'cooldown': 0}
 
         return state
+
+    def _capture_alignment_state(self):
+        state = {}
+
+        try:
+            duration_boost = float(getattr(self, '_alignment_duration_boost', 0.0))
+        except (TypeError, ValueError):
+            duration_boost = 0.0
+        if duration_boost != 0.0:
+            state['duration_boost'] = duration_boost
+
+        try:
+            diag_boost = float(getattr(self, '_alignment_diag_boost', 0.0))
+        except (TypeError, ValueError):
+            diag_boost = 0.0
+        if diag_boost != 0.0:
+            state['diag_boost'] = diag_boost
+
+        try:
+            diag_sigma = float(getattr(self, 'diagonal_attention_prior_sigma', 0.0))
+        except (TypeError, ValueError):
+            diag_sigma = 0.0
+        if diag_sigma > 0.0:
+            state['diag_sigma'] = diag_sigma
+
+        try:
+            blank_shift = float(getattr(self, '_alignment_blank_target_shift', 0.0))
+        except (TypeError, ValueError):
+            blank_shift = 0.0
+        if blank_shift != 0.0:
+            state['blank_target_shift'] = blank_shift
+
+        blank_min = getattr(self, '_alignment_blank_target_min', None)
+        if blank_min is not None:
+            try:
+                state['blank_target_min'] = float(blank_min)
+            except (TypeError, ValueError):
+                pass
+
+        blank_max = getattr(self, '_alignment_blank_target_max', None)
+        if blank_max is not None:
+            try:
+                state['blank_target_max'] = float(blank_max)
+            except (TypeError, ValueError):
+                pass
+
+        monitor_state = getattr(self, '_alignment_health_state', None)
+        if isinstance(monitor_state, dict) and monitor_state:
+            state['health_state'] = copy.deepcopy(monitor_state)
+
+        return state
+
+    def _restore_alignment_state(self, state):
+        if not isinstance(state, dict) or not state:
+            return
+
+        if 'duration_boost' in state:
+            try:
+                self._alignment_duration_boost = float(state['duration_boost'])
+            except (TypeError, ValueError):
+                self._alignment_duration_boost = 0.0
+
+        if 'diag_boost' in state:
+            try:
+                self._alignment_diag_boost = float(state['diag_boost'])
+            except (TypeError, ValueError):
+                self._alignment_diag_boost = 0.0
+
+        if 'diag_sigma' in state:
+            try:
+                sigma = float(state['diag_sigma'])
+            except (TypeError, ValueError):
+                sigma = None
+            if sigma is not None and sigma > 0.0:
+                self.diagonal_attention_prior_sigma = sigma
+
+        if 'blank_target_shift' in state:
+            try:
+                self._alignment_blank_target_shift = float(state['blank_target_shift'])
+            except (TypeError, ValueError):
+                self._alignment_blank_target_shift = 0.0
+
+        if 'blank_target_min' in state:
+            try:
+                self._alignment_blank_target_min = float(state['blank_target_min'])
+            except (TypeError, ValueError):
+                self._alignment_blank_target_min = None
+
+        if 'blank_target_max' in state:
+            try:
+                self._alignment_blank_target_max = float(state['blank_target_max'])
+            except (TypeError, ValueError):
+                self._alignment_blank_target_max = None
+
+        base_monitor_state = self._init_alignment_health_state()
+        saved_monitor_state = state.get('health_state')
+        if isinstance(saved_monitor_state, dict):
+            for key, section in saved_monitor_state.items():
+                if not isinstance(section, dict):
+                    continue
+                target_section = base_monitor_state.setdefault(key, {})
+                violations = section.get('violations')
+                cooldown = section.get('cooldown')
+                try:
+                    target_section['violations'] = int(violations)
+                except (TypeError, ValueError):
+                    target_section['violations'] = 0
+                try:
+                    target_section['cooldown'] = int(cooldown)
+                except (TypeError, ValueError):
+                    target_section['cooldown'] = 0
+        self._alignment_health_state = base_monitor_state
+
+        # Refresh any cached weights/targets that depend on the restored state.
+        self._get_attention_duration_weight()
+        self._set_active_diagonal_attention_weight(training=False)
+        if self.ctc_blank_rate_regularization_enabled:
+            self._get_ctc_blank_rate_target()
 
     def _current_ctc_blank_rate_weight(self, training: bool) -> float:
         cfg = self.ctc_blank_rate_regularization_config or {}
@@ -1683,6 +1802,10 @@ class Trainer(object):
             model_to_save = self.accelerator.unwrap_model(self.model)
         state_dict["model"] = model_to_save.state_dict()
 
+        alignment_state = self._capture_alignment_state()
+        if alignment_state:
+            state_dict["alignment_state"] = alignment_state
+
         if not os.path.exists(os.path.dirname(checkpoint_path)):
             os.makedirs(os.path.dirname(checkpoint_path))
         torch.save(state_dict, checkpoint_path)
@@ -1711,6 +1834,10 @@ class Trainer(object):
             self.scheduler.load_state_dict(state_dict["scheduler"])
 
         self._optimizer_step_count = self._get_optimizer_step_count()
+
+        alignment_state = state_dict.get("alignment_state")
+        if alignment_state:
+            self._restore_alignment_state(alignment_state)
 
         if not load_only_params:
             self._resumed_from_checkpoint = True


### PR DESCRIPTION
## Summary
- add an `alignment_health_monitor` block to the default config and document how to tune it
- teach the trainer to dynamically boost duration, diagonal, and blank-rate controls when diagnostics sag
- expose the adjusted weights/targets in train and eval metrics so regressions are easy to spot

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f1ef3b84a0833287c25a2bce22f8fe